### PR TITLE
Libraries to support using go-git

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,13 @@ communities about potential areas of collaboration.
 
 At this point in time, hydros is unlikely to work out of box for anyone outside of Primer
 as it makes several decisions specific to how Primer does CI/CD.
+
+
+# Binaries
+
+There are three binaries currently being built out of this repository
+
+* hydros - This is the main binary in this repository
+* sanitizer - This is a utility to help sanitize internal code before publishing it as public open source. It was
+   initially developed to aid in open sourcing hydros. It was inspired by a similar tool used at Google.
+* 

--- a/cmd/github/commands.go
+++ b/cmd/github/commands.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/jlewi/hydros/pkg/files"
@@ -62,7 +61,7 @@ func NewAppTokenCmd(w io.Writer, level *string, devLogger *bool) *cobra.Command 
 				if envFile != "" {
 					fmt.Fprintf(w, "Writing token to environment file %v", envFile)
 					perm := os.FileMode(int(0o700))
-					err := ioutil.WriteFile(envFile, []byte(fmt.Sprintf("export GITHUB_TOKEN=%v", token)), perm)
+					err := os.WriteFile(envFile, []byte(fmt.Sprintf("export GITHUB_TOKEN=%v", token)), perm)
 					if err != nil {
 						return errors.Wrapf(err, "Failed to write file %v", envFile)
 					}

--- a/cmd/sanitizer/app/sanitizer.go
+++ b/cmd/sanitizer/app/sanitizer.go
@@ -86,7 +86,7 @@ func (s *Sanitizer) Run(source string, dest string) error {
 		log.Info("Adding directory to list of excludes", "dir", filepath.Join(source, k))
 	}
 
-	topFiles, err := ioutil.ReadDir(source)
+	topFiles, err := os.ReadDir(source)
 	if err != nil {
 		return errors.Wrapf(err, "failed to read directory: %v", source)
 	}

--- a/cmd/sanitizer/main.go
+++ b/cmd/sanitizer/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/PrimerAI/go-micro-utils-public/gmu/logging"
@@ -63,7 +62,7 @@ func NewRunCmd() *cobra.Command {
 					input = wDir
 				}
 
-				b, err := ioutil.ReadFile(config)
+				b, err := os.ReadFile(config)
 				if err != nil {
 					return errors.Wrapf(err, "Failed to read config from path; %v", config)
 				}

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 require (
 	cloud.google.com/go/secretmanager v1.9.0
 	github.com/PrimerAI/go-micro-utils-public/gmu v0.0.0-20220526222947-c3eb3c2c79c8
+	github.com/go-git/go-git/v5 v5.4.2
 	github.com/thanhpk/randstr v1.0.4
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4
 	google.golang.org/grpc v1.50.1
@@ -68,8 +69,10 @@ require (
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Microsoft/go-winio v0.5.1 // indirect
 	github.com/Microsoft/hcsshim v0.8.23 // indirect
+	github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/acomagu/bufpipe v1.0.3 // indirect
 	github.com/alecthomas/chroma v0.8.2 // indirect
 	github.com/apex/log v1.9.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a // indirect
@@ -101,6 +104,8 @@ require (
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/go-errors/errors v1.0.1 // indirect
+	github.com/go-git/gcfg v1.5.0 // indirect
+	github.com/go-git/go-billy/v5 v5.3.1 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect
 	github.com/go-openapi/swag v0.19.15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -224,6 +224,7 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
 github.com/OpenPeeDeeP/depguard v1.0.1/go.mod h1:xsIw86fROiiwelg+jB2uM9PiKihMMmUx/1V+TNhjQvM=
 github.com/PrimerAI/go-micro-utils-public/gmu v0.0.0-20220526222947-c3eb3c2c79c8 h1:2iuGlOCj/PBNCfpRwFInkXwK2RdDO60QIx56LGPCE5U=
 github.com/PrimerAI/go-micro-utils-public/gmu v0.0.0-20220526222947-c3eb3c2c79c8/go.mod h1:pIBMNiq5XO4WvATnOU+7Jv7DRurufmOjP8zxIJGGCUs=
+github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
@@ -238,6 +239,7 @@ github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMx
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
+github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
@@ -705,10 +707,13 @@ github.com/go-critic/go-critic v0.4.3/go.mod h1:j4O3D4RoIwRqlZw5jJpx0BNfXWWbpcJo
 github.com/go-critic/go-critic v0.6.1/go.mod h1:SdNCfU0yF3UBjtaZGw6586/WocupMOJuiqgom5DsQxM=
 github.com/go-errors/errors v1.0.1 h1:LUHzmkK3GUKUrL/1gfBUxAHzcev3apQlezX/+O7ma6w=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
+github.com/go-git/gcfg v1.5.0 h1:Q5ViNfGF8zFgyJWPqYwA7qGFoMTEiBmdlkcfRmpIMa4=
 github.com/go-git/gcfg v1.5.0/go.mod h1:5m20vg6GwYabIxaOonVkTdrILxQMpEShl1xiMF4ua+E=
 github.com/go-git/go-billy/v5 v5.2.0/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI4Hb3ZqZ3W0=
+github.com/go-git/go-billy/v5 v5.3.1 h1:CPiOUAzKtMRvolEKw+bG1PLRpT7D3LIs3/3ey4Aiu34=
 github.com/go-git/go-billy/v5 v5.3.1/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI4Hb3ZqZ3W0=
 github.com/go-git/go-git-fixtures/v4 v4.2.1/go.mod h1:K8zd3kDUAykwTdDCr+I0per6Y6vMiRR/nnVTBtavnB0=
+github.com/go-git/go-git/v5 v5.4.2 h1:BXyZu9t0VkbiHtqrsvdq39UDhGJTl1h55VW6CSC4aY4=
 github.com/go-git/go-git/v5 v5.4.2/go.mod h1:gQ1kArt6d+n+BGd+/B/I74HwRTLhth2+zti4ihgckDc=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/pkg/github/auth.go
+++ b/pkg/github/auth.go
@@ -1,0 +1,59 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/bradleyfalzon/ghinstallation/v2"
+	"github.com/go-logr/zapr"
+	"go.uber.org/zap"
+)
+
+const (
+	// GitHubAppUsername is the username used by GitHub App's for basic auth.
+	GitHubAppUsername = "x-access-token"
+)
+
+// AppAuth implements BasicAuth for GitHub Apps for use with GoGit.
+// When authenticating as a GitHub App, we need to use basic auth with the username "x-access-token"
+//
+// Reference:
+// https://github.com/go-git/go-git/blob/c798d4a42004b1c8976a6a4f42f131f16d08b6fa/plumbing/transport/http/common.go#L191
+//
+// We also need to generate an appropriate token to use as the password. Since the token can expire we can't
+// use the existing BasicAuth.
+//
+// It is similar to go-git's BasicAuth.
+// https://github.com/go-git/go-git/blob/c798d4a42004b1c8976a6a4f42f131f16d08b6fa/plumbing/transport/http/common.go#L191
+type AppAuth struct {
+	Tr *ghinstallation.Transport
+}
+
+// SetAuth adds the appropriate authentication headers to the request.
+func (a *AppAuth) SetAuth(r *http.Request) {
+	if a == nil {
+		return
+	}
+
+	token, err := a.Tr.Token(context.Background())
+
+	if err != nil {
+		log := zapr.NewLogger(zap.L())
+		log.Error(err, "Failed to generate access token; requests will faill")
+	}
+	r.SetBasicAuth(GitHubAppUsername, token)
+}
+
+// Name is name of the auth method.
+func (a *AppAuth) Name() string {
+	return "http-basic-auth"
+}
+
+// String returns a sanitized string suitable for log messages.
+func (a *AppAuth) String() string {
+	masked := "*******"
+	masked = "<token to be generated>"
+
+	return fmt.Sprintf("%s - %s:%s", a.Name(), GitHubAppUsername, masked)
+}

--- a/pkg/github/auth_test.go
+++ b/pkg/github/auth_test.go
@@ -1,0 +1,51 @@
+//go:build integration
+
+package github
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-git/go-git/v5"
+)
+
+// Test_AppAuth is an integration test for the AppAuth. It verifies we can clone a private repository using
+// a GitHub App's credentials.
+func Test_AppAuth(t *testing.T) {
+	err := func() error {
+
+		tempDir, err := os.MkdirTemp("", "testClone")
+		if err != nil {
+			t.Fatalf("Failed to create temporary directory; %v", err)
+		}
+		defer os.RemoveAll(tempDir)
+
+		Org := "starlingai"
+		Repo := "gitops-test-repo"
+		manager, err := getTransportManager()
+		if err != nil {
+			return err
+		}
+
+		tr, err := manager.Get(Org, Repo)
+		if err != nil {
+			return err
+		}
+
+		fullDir := filepath.Join(tempDir, Org, Repo)
+		_, err = git.PlainClone(fullDir, false, &git.CloneOptions{
+			URL: fmt.Sprintf("https://github.com/%v/%v.git", Org, Repo),
+			Auth: &AppAuth{
+				Tr: tr,
+			},
+			Progress: os.Stdout,
+		})
+		return err
+	}()
+
+	if err != nil {
+		t.Fatalf("Failed with error:%+v", err)
+	}
+}

--- a/pkg/github/prs.go
+++ b/pkg/github/prs.go
@@ -2,8 +2,16 @@ package github
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
 	"github.com/cli/cli/api"
@@ -15,55 +23,116 @@ import (
 	"go.uber.org/zap"
 )
 
-// RepoHelper provides a higher level API ontop of the GraphQL API.
+// RepoHelper manages the local and remote operations involved in creating a PR.
+// RepoHelper is used to create a local working version of a repository where files can be modified.
+// Once those files have been modified they can be pushed to the remote repository and a PR  can be created
+//
+// TODO(jeremy): the code currently assumes the PR is created from a branch in the repository as opposed to creating
+// the PR from a fork. We should update the code to support using a fork.
 //
 // TODO(https://github.com/jlewi/hydros/issues/2): Migrage to github.com/shurcooL/githubv4
-// It is inspired by the higher level API in GitHub's GoLang CLI. A lot of the code is modified from that.
+// The functions CreatePR and PullRequestForBranch are inspired by the higher level API in GitHub's GoLang CLI.
+// A lot of the code is modified from that.
 //
-// We don't use the CLI The CLI authors suggested (https://github.com/cli/cli/issues/1327) that it would be better to use the API client
-// libraries directly; github.com/shurcooL/githubv4. The CLI API is providing higher level functions ontop of the
-// underlying GraphQL API; it seems silly to redo that rather than just import it and reuse it.
-// https://github.com/cli/cli/blob/4d28c791921621550f19a4c6bcc13778a7525025/api/queries_pr.go
+// We don't use the CLI. The CLI authors suggested (https://github.com/cli/cli/issues/1327) that it would be better to
+// use the API client  libraries directly; github.com/shurcooL/githubv4. The CLI API is providing higher level
+// functions ontop of the underlying GraphQL API; originally it seemed silly to redo that rather than just import it
+// and reuse it.  https://github.com/cli/cli/blob/4d28c791921621550f19a4c6bcc13778a7525025/api/queries_pr.go.
+// However, I think the CLI pulls in some dependencies (BlueMonday?) that we'd like to avoid pulling in if we can
+// so that's a good reason to try to migrate of the CLI package.
 type RepoHelper struct {
-	log       logr.Logger
-	transport *ghinstallation.Transport
-	client    *api.Client
-	baseRepo  ghrepo.Interface
+	log        logr.Logger
+	transport  *ghinstallation.Transport
+	client     *api.Client
+	baseRepo   ghrepo.Interface
+	fullDir    string
+	name       string
+	email      string
+	remote     string
+	BranchName string
+	BaseBranch string
+}
+
+// RepoHelperArgs is the arguments used to instantiate the object.
+type RepoHelperArgs struct {
+	// BaseRepo is the repository from which the branch is created. This is also the repository used to create the PR.
+	BaseRepo ghrepo.Interface
+	// GhTr is the GitHub transport used to authenticate as a GitHub App. If nil a transport will not be used.
+	GhTr    *ghinstallation.Transport
+	FullDir string
+	// Name is the name attached to commits.
+	Name string
+	// Email is the email attached to commits
+	Email string
+	// Remote is the name to use for the remote repository.
+	// Defaults to origin
+	Remote string
+
+	// BranchName is the name for the branch to be created
+	BranchName string
+
+	// BaseBranch is the name of the branch to use as the base.
+	// This is all the branch to which the PR will be merged
+	BaseBranch string
 }
 
 // NewGithubRepoHelper creates a helper for a specific repository.
 // transport - must be a transport configured with permission to access the referenced repository.
 // baseRepo - the repository to access.
-func NewGithubRepoHelper(transport *ghinstallation.Transport, baseRepo ghrepo.Interface, opts ...Option) (*RepoHelper, error) {
-	if transport == nil {
-		return nil, fmt.Errorf("transport is required")
+func NewGithubRepoHelper(args *RepoHelperArgs) (*RepoHelper, error) {
+	log := zapr.NewLogger(zap.L())
+
+	if args.GhTr == nil {
+		return nil, fmt.Errorf("GhTr is required")
 	}
-	if baseRepo == nil {
-		return nil, fmt.Errorf("baseRepo is required")
+	if args.BaseRepo == nil {
+		return nil, fmt.Errorf("BaseRepo is required")
+	}
+
+	if args.Remote == "" {
+		log.Info("Remote not set resorting to default", "remote", "origin")
+		args.Remote = "origin"
+	}
+
+	if args.BranchName == "" {
+		return nil, errors.New("BranchName is required")
+	}
+
+	if args.BaseBranch == "" {
+		return nil, errors.New("BaseBranch is required")
+	}
+
+	if args.FullDir == "" {
+		tempDir, err := os.MkdirTemp("", "syncer")
+		if err != nil {
+			return nil, errors.Wrapf(err, "Failed to create temporary dir to host the clone")
+		}
+		args.FullDir = filepath.Join(tempDir, args.BaseRepo.RepoOwner(), args.BaseRepo.RepoName())
+		log.Info("FullDir isn't set using a default value", "dir", args.FullDir)
+	}
+	if args.Name == "" {
+		args.Name = "unidentified-bot"
+		log.Info("No name specified; using default", "name", args.Name)
+	}
+
+	if args.Email == "" {
+		args.Email = "unidentified@nota.real.domain.com"
+		log.Info("No email specified; using default", "name", args.Email)
 	}
 
 	h := &RepoHelper{
-		transport: transport,
-		client:    api.NewClient(api.ReplaceTripper(transport)),
-		baseRepo:  baseRepo,
-		log:       zapr.NewLogger(zap.L()),
-	}
-
-	for _, o := range opts {
-		o(h)
+		transport:  args.GhTr,
+		client:     api.NewClient(api.ReplaceTripper(args.GhTr)),
+		baseRepo:   args.BaseRepo,
+		log:        zapr.NewLogger(zap.L()),
+		fullDir:    args.FullDir,
+		email:      args.Email,
+		remote:     args.Remote,
+		BranchName: args.BranchName,
+		BaseBranch: args.BaseBranch,
 	}
 
 	return h, nil
-}
-
-// Option creates an option for RepoHelper.
-type Option func(h *RepoHelper)
-
-// WithLogger creates an option to use the supplied logger.
-func WithLogger(log logr.Logger) Option {
-	return func(h *RepoHelper) {
-		h.log = log
-	}
 }
 
 // CreatePr creates a pull request
@@ -72,12 +141,18 @@ func WithLogger(log logr.Logger) Option {
 //
 //	Forkref will either be OWNER:BRANCH when a different repository is used as the fork.
 //	or it will be just BRANCH when merging from a branch in the same Repo as Repo
-func (h *RepoHelper) CreatePr(baseBranch, forkRef, prMessage string, labels []string) error {
+func (h *RepoHelper) CreatePr(prMessage string, labels []string) error {
 	log := h.log.WithValues("Repo", h.baseRepo.RepoName(), "Org", h.baseRepo.RepoOwner())
 	lines := strings.SplitN(prMessage, "\n", 2)
 
 	title := ""
 	body := ""
+
+	// Forkref will either be OWNER:BRANCH when a different repository is used as the fork.
+	//	or it will be just BRANCH when merging from a branch in the same Repo as Repo
+	// TODO(jeremy): forkRef should be turned into a struct variable and properly set so as to support
+	// creating PRs from forks.
+	forkRef := h.BranchName
 
 	if len(lines) >= 1 {
 		title = lines[0]
@@ -116,26 +191,14 @@ func (h *RepoHelper) CreatePr(baseBranch, forkRef, prMessage string, labels []st
 		"title": title,
 		"body":  body,
 		"draft": false,
-		// The name of the branch to merge changes into.
-		"baseRefName": baseBranch,
+		// The name of the branch to merge changes into. This is also the branch we branched from.
+		"baseRefName": h.BaseBranch,
 		// The name of the reference to merge changes from; typically in the form $user:$branch
-		"headRefName": forkRef,
+		"headRefName": h.BranchName,
 	}
 
 	if len(labelIds) > 0 {
 		params["labelIds"] = labelIds
-	}
-	// Forkref will either be OWNER:BRANCH when a different repository is used as the fork.
-	// Or it will be just BRANCH when merging from a branch in the same Repo as Repo
-	pieces := strings.Split(forkRef, ":")
-
-	forkOwner := h.baseRepo.RepoOwner()
-	forkBranch := ""
-	if len(pieces) == 1 {
-		forkBranch = pieces[0]
-	} else {
-		forkOwner = pieces[0]
-		forkBranch = pieces[1]
 	}
 
 	// Query the GitHub API to get actual repository info.
@@ -165,19 +228,9 @@ func (h *RepoHelper) CreatePr(baseBranch, forkRef, prMessage string, labels []st
 			h.log.Info(gErr.Message)
 
 			// Try to fetch and print out the URL of the existing PR.
-
-			// If the fork is in a different Repo then the head reference is OWNER:BRANCH
-			// If we are creating the PR from a different branch in the same Repo as where we are creating
-			// the PR then we just use BRANCH as the ref
-			headBranchRef := forkRef
-
-			if forkOwner == h.baseRepo.RepoOwner() {
-				headBranchRef = forkBranch
-			}
-
-			existingPR, err := h.PullRequestForBranch(baseBranch, headBranchRef)
+			existingPR, err := h.PullRequestForBranch()
 			if err != nil {
-				h.log.Error(err, "Failed to locate existing PR", "forkRef", forkRef, "baseBranch", baseBranch)
+				h.log.Error(err, "Failed to locate existing PR", "forkRef", forkRef, "baseBranch", h.BaseBranch)
 				return err
 			}
 
@@ -185,7 +238,7 @@ func (h *RepoHelper) CreatePr(baseBranch, forkRef, prMessage string, labels []st
 			if existingPR != nil {
 				url = existingPR.URL
 			}
-			h.log.Info("A pull request for the branch already exists", "forkRef", forkRef, "baseBranch", baseBranch, "prUrl", url)
+			h.log.Info("A pull request for the branch already exists", "forkRef", forkRef, "baseBranch", h.BaseBranch, "prUrl", url)
 		}
 	}
 	h.log.Info("Created PR", "url", pr.URL)
@@ -193,7 +246,9 @@ func (h *RepoHelper) CreatePr(baseBranch, forkRef, prMessage string, labels []st
 }
 
 // PullRequestForBranch returns the PR for the given branch if it exists and nil if no PR exists.
-func (h *RepoHelper) PullRequestForBranch(baseBranch, headBranch string) (*PullRequest, error) {
+func (h *RepoHelper) PullRequestForBranch() (*PullRequest, error) {
+	baseBranch := h.BaseBranch
+	headBranch := h.BranchName
 	type response struct {
 		Repository struct {
 			PullRequests struct {
@@ -258,4 +313,237 @@ func (h *RepoHelper) PullRequestForBranch(baseBranch, headBranch string) (*PullR
 	}
 
 	return nil, nil
+}
+
+// PrepareBranch prepares a branch. This will do the following
+// 1. Clone the repository if it hasn't already been cloned
+// 2. Create a branch if one doesn't already exist.
+//
+// If dropChanges is true if the working tree is direty the changes will be ignored.
+func (h *RepoHelper) PrepareBranch(dropChanges bool) error {
+	log := zapr.NewLogger(zap.L())
+	log = log.WithValues("org", h.baseRepo.RepoOwner(), "repo", h.baseRepo.RepoName(), "dir", h.fullDir)
+
+	// Generate an access token
+	url := fmt.Sprintf("https://github.com/%v/%v.git", h.baseRepo.RepoOwner(), h.baseRepo.RepoName())
+	var appAuth *AppAuth
+	if h.transport != nil {
+		appAuth = &AppAuth{
+			Tr: h.transport,
+		}
+	}
+
+	log.Info("URL and Auth configured", "url", url, "appAuth", appAuth)
+
+	// Clone the repository if it hasn't already been cloned.
+	err := func() error {
+		if _, err := os.Stat(h.fullDir); err == nil {
+			log.Info("Directory exists; repository will not be cloned", "directory", h.fullDir)
+			return nil
+		}
+
+		opts := &git.CloneOptions{
+			URL:      url,
+			Auth:     appAuth,
+			Progress: os.Stdout,
+		}
+
+		_, err := git.PlainClone(h.fullDir, false, opts)
+		return err
+	}()
+
+	if err != nil {
+		return err
+	}
+
+	// Open the repository
+	r, err := git.PlainOpenWithOptions(h.fullDir, &git.PlainOpenOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "Could not open respoistory at %v; ensure the directory contains a git repo", h.fullDir)
+	}
+
+	// Do a fetch to make sure the remote is up to date.
+	log.Info("Fetching remote", "remote", h.remote)
+	if err := r.Fetch(&git.FetchOptions{
+		RemoteName: h.remote,
+		Auth:       appAuth,
+	}); err != nil {
+		// Fetch returns an error if its already up to date and we want to ignore that.
+		if err.Error() != "already up-to-date" {
+			return err
+		}
+	}
+
+	// config reads .git/config
+	// We can use this to determine how the repository is setup to figure out what we need to do
+	cfg, err := r.Config()
+	if err != nil {
+		return err
+	}
+
+	// Set email and name of the author
+	// This is equivalent to git config user.email
+	log.Info("Updating email and name for commits")
+	cfg.User.Email = h.email
+	cfg.User.Name = h.name
+
+	// Need to update the config for the changes to take effect
+	if err := r.Storer.SetConfig(cfg); err != nil {
+		return err
+	}
+
+	// Check the status and error out if the try is dirty. We might want to add options to controll
+	// the behavior in the event the tree is dirty.
+	w, err := r.Worktree()
+	if err != nil {
+		return err
+	}
+
+	status, err := w.Status()
+	if err != nil {
+		return err
+	}
+
+	if !status.IsClean() {
+		if dropChanges {
+			log.Info("Working tree is dirty but dropChanges is true so changes will be dropped")
+		} else {
+			return errors.Errorf("Repository is dirty; this blocks branch creation")
+		}
+	}
+
+	// We need to get a reference to the remote base because that'h the hash we want to create the branch from
+	// Do we want to set resolved to true?
+	baseRef, err := r.Reference(h.RemoteBaseRef(), false)
+	if err != nil {
+		return err
+	}
+
+	// Try to get a reference to the local branch. We use this to determine whether the branch already exists
+	branchRef, err := r.Reference(h.BranchRef(), false)
+
+	checkoutOptions := &git.CheckoutOptions{
+		Branch: h.BranchRef(),
+		// TODO(jeremy): add an option to set Force to true to drop local changes?
+		Force: dropChanges,
+	}
+	if err != nil {
+		if err.Error() != "reference not found" {
+			return err
+		}
+		// Since the branch doesn't exist create it.
+		// We specify the Hash to be the latest hash on the remote branch
+		checkoutOptions.Create = true
+		checkoutOptions.Hash = baseRef.Hash()
+	} else {
+		log.Info("Got local and base references", "local", branchRef.Hash(), "base", baseRef.Hash())
+		if branchRef.Hash() != baseRef.Hash() {
+			// TODO(jeremy): Can/should we update the local branch in this case? Rather than just overwriting the
+			// branch.
+			if dropChanges {
+				log.Info("Branch already exists but is not based on the baseref; the changes will be overwritten", "local", branchRef.Hash(), "base", baseRef.Hash())
+			} else {
+				return errors.Errorf("PrepareBranch failed. The branch %v exists at hash %v but the baseRef %v is at hash %v", h.BranchName, branchRef.Hash(), h.BaseBranch, baseRef.Hash())
+			}
+		}
+		// since the branch already exists we just have to check it out
+		checkoutOptions.Create = false
+	}
+
+	log.Info("Checking out branch", "name", h.BaseBranch, "baseRef", h.RemoteBaseRef())
+	err = w.Checkout(checkoutOptions)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CommitAndPush and push commits and pushes all the working changes
+//
+// NullOp if nothing to commit.
+//
+// force means the remote branch will be overwritten if it isn't in sync.
+func (h *RepoHelper) CommitAndPush(message string, force bool) error {
+	log := zapr.NewLogger(zap.L())
+	log = log.WithValues("org", h.baseRepo.RepoOwner(), "repo", h.baseRepo.RepoName(), "dir", h.fullDir)
+	// Open the repository
+	r, err := git.PlainOpenWithOptions(h.fullDir, &git.PlainOpenOptions{})
+	if err != nil {
+		return err
+	}
+	w, err := r.Worktree()
+	if err != nil {
+		return err
+	}
+	status, err := w.Status()
+	if err != nil {
+		return err
+	}
+	if status.IsClean() {
+		log.Info("No changes to commit")
+		return nil
+	}
+
+	if err := w.AddWithOptions(&git.AddOptions{All: true}); err != nil {
+		return err
+	}
+
+	commit, err := w.Commit(message, &git.CommitOptions{
+		Author: &object.Signature{
+			Name:  h.name,
+			Email: h.email,
+			When:  time.Now(),
+		},
+	})
+
+	if err != nil {
+		return err
+	}
+
+	// Prints the current HEAD to verify that all worked well.
+	obj, err := r.CommitObject(commit)
+	if err != nil {
+		return err
+	}
+	log.Info("Commit succeeded", "commit", obj.String())
+
+	// We will name the remote branch the same as the local branch so src and dest are the same
+	refSpec := string(h.BranchRef()) + ":" + string(h.BranchRef())
+
+	var appAuth *AppAuth
+	if h.transport != nil {
+		appAuth = &AppAuth{
+			Tr: h.transport,
+		}
+	}
+
+	log.Info("Pushing", "refspec", refSpec, "appAuth", appAuth)
+
+	if err := r.Push(&git.PushOptions{
+		RemoteName: h.remote,
+		RefSpecs: []config.RefSpec{
+			config.RefSpec(refSpec),
+		},
+		Auth:  appAuth,
+		Force: force,
+	}); err != nil {
+		return err
+	}
+
+	log.Info("Push succeeded")
+	return nil
+}
+
+// BranchRef returns reference to the branch we created
+func (h *RepoHelper) BranchRef() plumbing.ReferenceName {
+	return plumbing.ReferenceName(fmt.Sprintf("refs/heads/%v", h.BranchName))
+}
+
+// RemoteBaseRef returns the remote base reference.
+// Per https://git-scm.com/book/en/v2/Git-Internals-The-Refspec
+// This is the local copy of the remote branch.
+func (h *RepoHelper) RemoteBaseRef() plumbing.ReferenceName {
+	return plumbing.ReferenceName(fmt.Sprintf("refs/remotes/%v/%v", h.remote, h.BaseBranch))
 }

--- a/pkg/github/prs_test.go
+++ b/pkg/github/prs_test.go
@@ -1,0 +1,221 @@
+//go:build integration
+
+package github
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-logr/zapr"
+	"github.com/jlewi/hydros/pkg/files"
+	"github.com/jlewi/hydros/pkg/util"
+	"github.com/kubeflow/testing/go/pkg/ghrepo"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+)
+
+const (
+	appID      = int64(263648)
+	privateKey = "gcpSecretManager:///projects/dev-starling/secrets/annotater-bot/versions/latest"
+)
+
+func getTransportManager() (*TransportManager, error) {
+	log := zapr.NewLogger(zap.L())
+
+	f := &files.Factory{}
+	h, err := f.Get(privateKey)
+	if err != nil {
+		return nil, err
+	}
+	r, err := h.NewReader(privateKey)
+	if err != nil {
+		return nil, err
+	}
+	secretByte, err := io.ReadAll(r)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return NewTransportManager(appID, secretByte, log)
+}
+
+func checkDirAtCommit(fullDir string, expected string) error {
+	// Open the repository and get the current hash to verify it is the expected hash.
+	// Open the repository
+	r, err := git.PlainOpenWithOptions(fullDir, &git.PlainOpenOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "Could not open respoistory at %v; ensure the directory contains a git repo", fullDir)
+	}
+
+	hash, err := r.Head()
+	if err != nil {
+		return err
+	}
+
+	if hash.Hash().String() != expected {
+		return errors.Errorf("Unexpected hash; Got %v; want %v", hash.String(), expected)
+	}
+	return nil
+}
+
+// Test_PrepareBranch is an integration test.
+func Test_PrepareBranch(t *testing.T) {
+	// This test verifies that we can check out a repository to a clean directory
+	log := util.SetupLogger("debug", true)
+
+	tempDir, err := os.MkdirTemp("", "testClone")
+	if err != nil {
+		t.Fatalf("Failed to create temporary directory; %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	now := time.Now().Format("20060102-030405")
+
+	// expected should be the current latest commit on the branch we are testing. If new commits are
+	// added this will need to be updated
+	expected := "a9b473353b73a4cd5e2c8809c4c16a0e9e164129"
+
+	args := &RepoHelperArgs{
+		BaseRepo:   ghrepo.New("starlingai", "gitops-test-repo"),
+		GhTr:       nil,
+		Name:       "notset",
+		Email:      "notset@acme.com",
+		BaseBranch: "test-cases/clone-1",
+		BranchName: "clone-test" + now,
+	}
+
+	args.FullDir = filepath.Join(tempDir, args.BaseRepo.RepoOwner(), args.BaseRepo.RepoName())
+	err = func() error {
+		manager, err := getTransportManager()
+		if err != nil {
+			return err
+		}
+
+		tr, err := manager.Get(args.BaseRepo.RepoOwner(), args.BaseRepo.RepoName())
+		if err != nil {
+			return err
+		}
+
+		args.GhTr = tr
+
+		repo, err := NewGithubRepoHelper(args)
+
+		if err != nil {
+			return err
+		}
+
+		if err := repo.PrepareBranch(true); err != nil {
+			return err
+		}
+
+		if err := checkDirAtCommit(args.FullDir, expected); err != nil {
+			return err
+		}
+
+		log.Info("Initial clone succeeded; checking out a different branch and retrying")
+
+		// Run PrepareBranch a second time this way we can verify we can clone the repository even when we
+		// are already checked out. First checkout a different branch
+		if err := func() error {
+			r, err := git.PlainOpenWithOptions(repo.fullDir, &git.PlainOpenOptions{})
+			if err != nil {
+				return errors.Wrapf(err, "Could not open respoistory at %v; ensure the directory contains a git repo", repo.fullDir)
+			}
+
+			w, err := r.Worktree()
+			if err != nil {
+				return err
+			}
+			if err := w.Checkout(&git.CheckoutOptions{
+				Branch: "refs/heads/main",
+			}); err != nil {
+				return err
+			}
+			return nil
+		}(); err != nil {
+			return err
+		}
+
+		if err := repo.PrepareBranch(true); err != nil {
+			return err
+		}
+
+		if err := checkDirAtCommit(args.FullDir, expected); err != nil {
+			return err
+		}
+
+		return nil
+	}()
+
+	if err != nil {
+		t.Fatalf("Failed to clone the repository; error %+v", err)
+	}
+}
+
+// Test_PrepareCommitAndPush tests that we can go through the full cycle of checking out a branch,
+// modifying it, and then committing and pushing the changes.
+func Test_PrepareCommitAndPush(t *testing.T) {
+	util.SetupLogger("debug", true)
+
+	tempDir, err := os.MkdirTemp("", "testClone")
+	if err != nil {
+		t.Fatalf("Failed to create temporary directory; %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	now := time.Now().Format("20060102-030405")
+
+	args := &RepoHelperArgs{
+		BaseRepo:   ghrepo.New("starlingai", "gitops-test-repo"),
+		GhTr:       nil,
+		Name:       "notset",
+		Email:      "notset@acme.com",
+		BaseBranch: "test-cases/clone-1",
+		BranchName: "clone-test" + now,
+	}
+
+	args.FullDir = filepath.Join(tempDir, args.BaseRepo.RepoOwner(), args.BaseRepo.RepoName())
+	err = func() error {
+		manager, err := getTransportManager()
+		if err != nil {
+			return err
+		}
+
+		tr, err := manager.Get(args.BaseRepo.RepoOwner(), args.BaseRepo.RepoName())
+		if err != nil {
+			return err
+		}
+
+		args.GhTr = tr
+
+		repo, err := NewGithubRepoHelper(args)
+
+		if err != nil {
+			return err
+		}
+
+		if err := repo.PrepareBranch(true); err != nil {
+			return err
+		}
+
+		// Write a file
+		filename := filepath.Join(repo.fullDir, "test-file-"+now+".txt")
+		if err := os.WriteFile(filename, []byte("hello world"), util.FilePermUserGroup); err != nil {
+			return err
+		}
+
+		if err := repo.CommitAndPush("Commit from test", true); err != nil {
+			return err
+		}
+		return nil
+	}()
+
+	if err != nil {
+		t.Fatalf("Failed to clone the repository; error %+v", err)
+	}
+}

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -4,6 +4,6 @@ const (
 	// ContentTypeJSON is a constant for the application type of requests.
 	ContentTypeJSON = "application/json"
 
-	// FilePermUserGroup value of permissions user ang roup all permissions
+	// FilePermUserGroup value of permissions user and group all permissions
 	FilePermUserGroup = 0o770
 )


### PR DESCRIPTION
* This PR contains code that will enable using git programmatically via go-git as opposed to shelling out to the git CLI

This PR updates RepoHelper to support cloning, branching, committing, and pushing
 code using go-git

 * In a follow on PR we will update Syncer to use this functionality rather than shelling out to git.

 * Create some integration tests for testing this. This is behind a go build flag.

 * This leads to the function signature of CreatePR and PullRequestForBranch being changed since some of the function args should not be obtained from the struct rather than passed as command line arguments.

Add a GoGit Auth implementation that works for authenticating as a GitHub App

* This is just basic auth with the username x-access-code
* We also need to generate the token which is used as the password on every call since the token expires.

Related to https://github.com/jlewi/hydros/issues/3 ; this is tracking the migration from using git CLI to using go-git.

Fix some but not all deprecated reefrences to ioutil.

Update the README to describe some of the other code in this repository