### PR TITLE
Support developers taking over the dev environment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,12 @@ There are three binaries currently being built out of this repository
 * hydros - This is the main binary in this repository
 * sanitizer - This is a utility to help sanitize internal code before publishing it as public open source. It was
    initially developed to aid in open sourcing hydros. It was inspired by a similar tool used at Google.
-* 
+
+# Installing Hydros On Your Repositories
+
+1. Create a GitHub App
+   * Grant it the permissions
+     * Contents - Read & Write
+     * Pull Requests - Read & Write
+2. Generate a private key for the github app
+3. Install it on the repositories that will be used as the source and destination

--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 const (
 	// Group for MLP tasks.
+	// TODO(jeremy): we should change this
 	Group = "mlp.primer.ai"
 	// Version for tasks.
 	Version = "v1alpha1"

--- a/cmd/commands/takeover.go
+++ b/cmd/commands/takeover.go
@@ -1,0 +1,114 @@
+package commands
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/go-logr/zapr"
+	"github.com/jlewi/hydros/api/v1alpha1"
+	"github.com/jlewi/hydros/pkg/files"
+	"github.com/jlewi/hydros/pkg/github"
+	"github.com/jlewi/hydros/pkg/gitops"
+	"github.com/jlewi/hydros/pkg/hydros"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
+)
+
+type TakeOverArgs struct {
+	WorkDir     string
+	Secret      string
+	GithubAppID int64
+	Force       bool
+	File        string
+	KeyFile     string
+	RepoDir     string
+}
+
+func NewTakeOverCmd() *cobra.Command {
+	opts := &TakeOverArgs{}
+	cmd := &cobra.Command{
+		Use:   "takeover -f <resource.yaml>",
+		Short: "Take over the dev environment by applying the specified configuration.",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := TakeOver(opts); err != nil {
+				fmt.Printf("takeover failed; error %+v\n", err)
+			}
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.WorkDir, "work-dir", "", "", "Directory where repos should be checked out")
+	cmd.Flags().StringVarP(&opts.Secret, "private-key", "", "", "Path to the file containing the secret for the GitHub App to Authenticate as.")
+	cmd.Flags().Int64VarP(&opts.GithubAppID, "appId", "", hydros.HydrosGitHubAppID, "GitHubAppId.")
+	cmd.Flags().BoolVarP(&opts.Force, "force", "", false, "Force a sync even if one isn't needed.")
+	cmd.Flags().StringVarP(&opts.File, "file", "", "", "Force a sync even if one isn't needed.")
+	cmd.Flags().StringVarP(&opts.KeyFile, "ssh-key-file", "", "", "(Optional) Path of PEM file containing ssh key used to push current changes. If blank will try to find key in ${HOME}/.ssh.")
+	cmd.Flags().StringVarP(&opts.RepoDir, "repo-dir", "", "", "(Optional) Directory containing the source repo that should be pushed. If blank it is inferred based on the path of the --file argument")
+
+	cmd.MarkFlagRequired("file")
+
+	return cmd
+}
+
+func readSecret(secret string) ([]byte, error) {
+	f := &files.Factory{}
+	h, err := f.Get(secret)
+	if err != nil {
+		return nil, err
+	}
+	r, err := h.NewReader(secret)
+	if err != nil {
+		return nil, err
+	}
+	return io.ReadAll(r)
+}
+
+func TakeOver(args *TakeOverArgs) error {
+	log := zapr.NewLogger(zap.L())
+
+	secret, err := readSecret(args.Secret)
+	if err != nil {
+		return errors.Wrapf(err, "Could not read file: %v", args.Secret)
+	}
+	manager, err := github.NewTransportManager(int64(args.GithubAppID), secret, log)
+	if err != nil {
+		log.Error(err, "TransportManager creation failed")
+		return err
+	}
+
+	f, err := os.Open(args.File)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to open file: %v", args.File)
+	}
+
+	d := yaml.NewDecoder(f)
+
+	m := &v1alpha1.ManifestSync{}
+
+	if err := d.Decode(m); err != nil {
+		return errors.Wrapf(err, "Failed to decode ManifestSync from file %v", args.File)
+	}
+
+	syncer, err := gitops.NewSyncer(m, manager, gitops.SyncWithWorkDir(args.WorkDir), gitops.SyncWithLogger(log))
+	if err != nil {
+		return err
+	}
+
+	if args.RepoDir == "" {
+		args.RepoDir = filepath.Dir(args.File)
+		log.Info("RepoDir is using default", "repoDir", args.RepoDir)
+	}
+
+	if err := syncer.PushLocal(args.RepoDir, args.KeyFile); err != nil {
+		return err
+	}
+
+	if err := syncer.RunOnce(args.Force); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/commands/takeover_test.go
+++ b/cmd/commands/takeover_test.go
@@ -1,0 +1,48 @@
+//go:build integration
+
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jlewi/hydros/pkg/util"
+)
+
+const (
+	appID      = int64(266158)
+	privateKey = "secrets/hydros-bot.2022-11-27.private-key.pem"
+)
+
+// Test_TakeOver is an integration test for the PushLocal function.
+func Test_TakeOver(t *testing.T) {
+	util.SetupLogger("info", true)
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get cwd; %v", err)
+	}
+
+	syncFile := filepath.Join(cwd, "test_data", "devsync.yaml")
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("Could not get home directory; %v", err)
+	}
+
+	hydrosKeyFile := filepath.Join(home, privateKey)
+
+	args := &TakeOverArgs{
+		WorkDir:     "",
+		Secret:      hydrosKeyFile,
+		GithubAppID: appID,
+		Force:       false,
+		File:        syncFile,
+		KeyFile:     "",
+		RepoDir:     "",
+	}
+
+	if err := TakeOver(args); err != nil {
+		t.Fatalf("Takeover failed; error %+v", err)
+	}
+}

--- a/cmd/commands/test_data/devsync.yaml
+++ b/cmd/commands/test_data/devsync.yaml
@@ -1,0 +1,24 @@
+# This configuration is for taking over dev
+apiVersion: mlp.primer.ai/v1alpha1
+kind: ManifestSync
+metadata:
+  name: pushloccal-test
+spec:
+  sourceRepo:
+    org: jlewi
+    repo: hydros
+    branch: dev-takeover
+  forkRepo:
+    org: jlewi
+    repo: hydros-hydrated
+    branch: hydros/dev-takeover
+  destRepo:
+    org: jlewi
+    repo: hydros-hydrated
+    branch: main
+  sourcePath: ""
+  selector:
+    matchLabels:
+      app: hydros
+      environment: dev
+  destPath: hydros

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jlewi/hydros/cmd/commands"
+
 	"github.com/jlewi/hydros/pkg/files"
 	"github.com/pkg/errors"
 
@@ -174,6 +176,7 @@ func init() {
 	rootCmd.AddCommand(tagCmd)
 	rootCmd.AddCommand(newVersionCmd(os.Stdout))
 	rootCmd.AddCommand(githubCmds.NewAppTokenCmd(os.Stdout, &gOptions.level, &gOptions.devLogger))
+	rootCmd.AddCommand(commands.NewTakeOverCmd())
 
 	rootCmd.PersistentFlags().BoolVar(&gOptions.devLogger, "dev-logger", false, "If true configure the logger for development; i.e. non-json output")
 	rootCmd.PersistentFlags().StringVarP(&gOptions.level, "log-level", "", "info", "Log level: error info or debug")

--- a/pkg/gitutil/gitutil.go
+++ b/pkg/gitutil/gitutil.go
@@ -1,8 +1,16 @@
 package gitutil
 
 import (
+	"bufio"
 	"os"
 	"path/filepath"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
+	"github.com/go-logr/zapr"
+	"github.com/jlewi/hydros/pkg/util"
+	"go.uber.org/zap"
 
 	"github.com/pkg/errors"
 )
@@ -26,4 +34,74 @@ func LocateRoot(path string) (string, error) {
 		}
 		return "", errors.Wrapf(err, "Error checking for directory %v", gDir)
 	}
+}
+
+// AddGitignoreToWorktree adds the exclude paths in the .gitignore file to the worktree.
+// This is a workaround for https://github.com/go-git/go-git/issues/597. If we don't call this before doing add
+// all then the ignore patterns won't be respected.
+//
+// N.B this doesn't work with nested .gitignore files.
+func AddGitignoreToWorktree(wt *git.Worktree, repositoryPath string) error {
+	log := zapr.NewLogger(zap.L())
+
+	path := filepath.Join(repositoryPath, ".gitignore")
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		log.Info("No .gitignore file for repository", "repository", repositoryPath)
+		return nil
+	}
+	readFile, err := os.Open(path)
+	defer readFile.Close()
+
+	if err != nil {
+		return errors.Wrapf(err, "Failed to read .gitignore: %s", path)
+	}
+
+	fileScanner := bufio.NewScanner(readFile)
+	fileScanner.Split(bufio.ScanLines)
+
+	for fileScanner.Scan() {
+		ignorePattern := fileScanner.Text()
+		log.V(util.Debug).Info("add .gitignore pattern to ignore list", "pattern", ignorePattern)
+		wt.Excludes = append(wt.Excludes, gitignore.ParsePattern(ignorePattern, nil))
+	}
+	return nil
+}
+
+type User struct {
+	Name  string
+	Email string
+}
+
+// LoadUser gets the user information for the repository.
+func LoadUser(r *git.Repository) (*User, error) {
+	cfg, err := r.Config()
+	if err != nil {
+		return nil, err
+	}
+
+	user := &User{
+		Name:  cfg.User.Name,
+		Email: cfg.User.Email,
+	}
+
+	if user.Name != "" && user.Email != "" {
+		return user, nil
+	}
+
+	// Since Name and/or Email aren't set in the local scope. Try the global scope
+	gCfg, err := config.LoadConfig(config.GlobalScope)
+	if err != nil {
+		return user, errors.Wrapf(err, "Failed to load GlobalConfig")
+	}
+
+	if user.Name == "" {
+		user.Name = gCfg.User.Name
+	}
+	if user.Email == "" {
+		user.Email = gCfg.User.Email
+	}
+
+	// N.B it doesn't make sense to check the system configuration because that would apply to all users
+	// so why would you set the name and email their?
+	return user, nil
 }


### PR DESCRIPTION
* See https://github.com/jlewi/hydros/issues/9

* This PR adds the command `hydros takeover ...` which can be used to hydrate based on the locally modified changes by taking over the deve environment.

* This PR adds a PushLocal function which will automatically push any changes to the SourceRepo branch listed in a ManifestSync

* The Syncer can then be used to apply the Manifest in order to push the local changes to the dev environment.

* Fix an issue in RepoHelper with .gitignore not being respected when adding files

  * We need to explicitly load and parse the .gitignore files and add the expresions to the worktree
  * go-gits implementation doesn't do this by default.

* Start a directory to contain documentation.