### PR TITLE
Improved handling of PR merging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,13 @@ tidy-go:
 	gofmt -s -w .
 	goimports -w .
 	
+tidy: tidy-go
+
 lint-go:
 	# golangci-lint automatically searches up the root tree for configuration files.
 	golangci-lint run
+
+lint: lint-go
 
 test-go:
 	go test -v ./...

--- a/cmd/sanitizer/app/sanitizer.go
+++ b/cmd/sanitizer/app/sanitizer.go
@@ -177,7 +177,7 @@ func isUnsafeError(e error) bool {
 
 func (s *Sanitizer) cleanFile(path string, dest string) error {
 	s.log.Info("Cleaning target", "target", path)
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to clean file; %v", path)
 	}

--- a/cmd/sanitizer/app/sanitizer_test.go
+++ b/cmd/sanitizer/app/sanitizer_test.go
@@ -12,7 +12,7 @@ import (
 
 // Not really a unittest as we try to sanitize the hydros directory
 func Test_sanitize(t *testing.T) {
-	dir, err := ioutil.TempDir("", "testSanitize")
+	dir, err := os.MkdirTemp("", "testSanitize")
 	if err != nil {
 		t.Fatalf("Failed to create temporary directory; error %v", err)
 	}

--- a/pkg/gitutil/gitutil.go
+++ b/pkg/gitutil/gitutil.go
@@ -50,7 +50,7 @@ func AddGitignoreToWorktree(wt *git.Worktree, repositoryPath string) error {
 		return nil
 	}
 	readFile, err := os.Open(path)
-	defer readFile.Close()
+	util.DeferIgnoreError(readFile.Close)
 
 	if err != nil {
 		return errors.Wrapf(err, "Failed to read .gitignore: %s", path)


### PR DESCRIPTION
* This PR reduces the reliance on GitHub's automerge feature by adding improved handling of PR merging in the syncer.

* If a PR exists the syncer will attempt to merge it and wait for it to merge this allows the syncer to push any changes that might be blocked on the pending PR

* After creating a new PR with the latest changes the sycner will wait for the PR to be merged. This provides better handling in the case of dev takeover when automerge isn't (or can't be enabled) on the repository. There appears to be a bit of a race condition where the PR may not be merged right away even thought it should be immediately mergeable but this PR fixes that by having a retry loop that will wait for the PR to me merged and periodically retry merging

* Fix #21
* Fix #17