### PR TITLE
Fix a bug in AddGitIgnore preventing .gitignore from being respected

### DIFF
--- a/docs/ai_generation.md
+++ b/docs/ai_generation.md
@@ -10,7 +10,7 @@ related to inference.
 
 There are two parts to configuring Hydros AI
 
-1. Configuring the HydrosAI KRM function
+1. Configuring the HydrosAI [KRM function](https://kpt.dev/book/02-concepts/03-functions)
    * This KRM function is responsible for generating the configuration changes
      from the natural language descriptions.
 2. Attaching `ai.hydros.io/${TAG}` annotations to your configuration files.
@@ -25,7 +25,7 @@ plugins into KRM function declarations.
 
 A major challenge to using Cloud is creating levels of abstraction for configuration that reflect the separation
 of concerns among teams [Tweet thread](https://twitter.com/kelseyhightower/status/1646538701818986501?s=20).
-For example, many developers within an organization may need to spin up a simple web apps accessible over the intranet. 
+For example, many developers within an organization may need to spin up simple web apps accessible over the intranet. 
 However, only a small number of developers may have a good understanding of networking 
 (e.g. ISTIO, Gateway, Certificates, etc...).
 
@@ -66,7 +66,7 @@ The developer can then run `hydros generate` to use AI to generate the KRM funct
 
 ## Configuring the HydrosAI KRM function
 
-Define a KPT function which specifies all the KRM functions you want Hydros to be aware of.
+Define a KRM function which specifies all the KRM functions you want Hydros to be aware of.
 For each KRM function provide a `FilterSpec` which is an OpenAPI schema of the function.
 Here's an example
 
@@ -178,4 +178,5 @@ containing the KRM function declarations generated from the annotation.
 
 ## References
 
-[Blog on Cruise's Teams](https://medium.com/cruise/building-a-container-platform-at-cruise-part-1-507f3d561e6f)
+[Blog on Cruise's Teams](https://medium.com/cruise/building-a-container-platform-at-cruise-part-1-507f3d561e6f) - A
+useful reference point for the myriad ways organizations can be structured.

--- a/pkg/gitops/renderer.go
+++ b/pkg/gitops/renderer.go
@@ -3,12 +3,13 @@ package gitops
 import (
 	"context"
 	"fmt"
-	"github.com/bradleyfalzon/ghinstallation/v2"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/bradleyfalzon/ghinstallation/v2"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-logr/zapr"

--- a/pkg/gitops/renderer_test.go
+++ b/pkg/gitops/renderer_test.go
@@ -1,6 +1,10 @@
 package gitops
 
 import (
+	"io"
+	"os"
+	"testing"
+
 	"github.com/go-logr/zapr"
 	"github.com/jlewi/hydros/api/v1alpha1"
 	"github.com/jlewi/hydros/pkg/files"
@@ -9,9 +13,6 @@ import (
 	"github.com/jlewi/hydros/pkg/util"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
-	"io"
-	"os"
-	"testing"
 )
 
 func readSecret(secret string) ([]byte, error) {

--- a/pkg/gitutil/gitutil.go
+++ b/pkg/gitutil/gitutil.go
@@ -50,7 +50,7 @@ func AddGitignoreToWorktree(wt *git.Worktree, repositoryPath string) error {
 		return nil
 	}
 	readFile, err := os.Open(path)
-	util.DeferIgnoreError(readFile.Close)
+	defer util.DeferIgnoreError(readFile.Close)
 
 	if err != nil {
 		return errors.Wrapf(err, "Failed to read .gitignore: %s", path)
@@ -61,8 +61,14 @@ func AddGitignoreToWorktree(wt *git.Worktree, repositoryPath string) error {
 
 	for fileScanner.Scan() {
 		ignorePattern := fileScanner.Text()
+		if ignorePattern == "" {
+			continue
+		}
 		log.V(util.Debug).Info("add .gitignore pattern to ignore list", "pattern", ignorePattern)
 		wt.Excludes = append(wt.Excludes, gitignore.ParsePattern(ignorePattern, nil))
+	}
+	if err := fileScanner.Err(); err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
* We were missing a defer statement for closing the file so
  we were closing the file before scanning it for .gitignore patterns

* As a result no patterns were detected; scanner reports an error but we
  weren't checking it.

Related to https://github.com/jlewi/hydros/issues/23