### PR TITLE
Don't initialize an AWS session by default.

### DIFF
--- a/pkg/gitops/syncer.go
+++ b/pkg/gitops/syncer.go
@@ -108,20 +108,6 @@ func NewSyncer(m *v1alpha1.ManifestSync, manager *github.TransportManager, opts 
 
 	s.workDir = filepath.Join(s.workDir, m.Metadata.Name)
 	s.log.Info("workdir is set.", "workDir", s.workDir)
-	if s.sess == nil {
-		// TODO(jeremy): Is there a better way to set the default region?
-		// The session can be injected via an option.
-		region := "us-west-2"
-		s.log.Info("Creating an AWS session using defaults.", "region", region)
-		sess, err := session.NewSession(&aws.Config{
-			Region: aws.String(region),
-		})
-		if err != nil {
-			s.log.Error(err, "Failed to create AWS session")
-			return nil, err
-		}
-		s.sess = sess
-	}
 	s.log = s.log.WithValues("ManifestSync.Name", s.manifest.Metadata.Name)
 
 	s.execHelper = &util.ExecHelper{

--- a/pkg/gitops/syncer.go
+++ b/pkg/gitops/syncer.go
@@ -591,7 +591,7 @@ func (s *Syncer) PushLocal(wDir string, keyFile string) error {
 	// GitHub uses git for the username.
 	appAuth, err := ssh.NewPublicKeysFromFile("git", keyFile, "")
 	if err != nil {
-		return errors.Wrapf(err, "Failed to load ssh key from keyfile %v", keyFile)
+		return errors.Wrapf(err, "Failed to load ssh key from keyfile %v; is your SSH key password protected? Hydros currently requires no password to be set", keyFile)
 	}
 	log.Info("Located root of git repository", "root", root, "wDir", wDir)
 	// Open the repository

--- a/pkg/gitops/syncer.go
+++ b/pkg/gitops/syncer.go
@@ -591,7 +591,7 @@ func (s *Syncer) PushLocal(wDir string, keyFile string) error {
 	// GitHub uses git for the username.
 	appAuth, err := ssh.NewPublicKeysFromFile("git", keyFile, "")
 	if err != nil {
-		return errors.Wrapf(err, "Failed to load ssh key")
+		return errors.Wrapf(err, "Failed to load ssh key from keyfile %v", keyFile)
 	}
 	log.Info("Located root of git repository", "root", root, "wDir", wDir)
 	// Open the repository

--- a/pkg/gitutil/gitutil_test.go
+++ b/pkg/gitutil/gitutil_test.go
@@ -89,12 +89,6 @@ func Test_GitIgnore(t *testing.T) {
 		t.Fatalf("Could not initialize git repo %v", err)
 	}
 
-	//storer := filesystem.NewStorage(osfs.New(dir), cache.NewObjectLRUDefault())
-	//r, err := git.Init(storer, nil)
-	//if err != nil {
-	//	t.Fatalf("Could not initialize git repo %v", err)
-	//}
-
 	// Creat a .gitignore file
 	gitIgnoreContents := `
 **/.build


### PR DESCRIPTION
Don't initialize an AWS session by default. 

AWS session can be initialized by an option but we currently don't expose it via the CLI