### PR TITLE
Temporarily disable releasing windows binaries because we started get…

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,7 +6,8 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
-      - windows
+      # TODO(https://github.com/jlewi/hydros/issues/71): Disable windows builds.
+      #- windows
       - darwin
 
     # N.B. No need to build for 386 architecture


### PR DESCRIPTION
…ting

a missing dependency error.
Related to #71