### PR TITLE
Better support for dev takeover

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,8 +17,8 @@ builds:
 
     # Custom ldflags templates.
     # Default is `-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser`.
-    #ldflags:
-      #- "-s -w -X github.com/jlewi/roboweb/kubedr/cmd/commands.version={{.Version}} -X github.com/jlewi/roboweb/kubedr/cmd/commands.commit={{.Commit}} -X github.com/jlewi/roboweb/kubedr/cmd/commands.date={{.Date}} -X github.com/jlewi/roboweb/kubedr/cmd/commands.builtBy=goreleaser"
+    ldflags:
+      - "-s -w -X github.com/jlewi/hydros/cmd/commands.version={{.Version}} -X github.com/jlewi/hydro/cmd/commands.commit={{.Commit}} -X github.com/jlewi/hydros/cmd/commands.date={{.Date}} -X github.com/jlewi/hydros/cmd/commands.builtBy=goreleaser"
 archives:
   # https://goreleaser.com/customization/archive/?h=archives
   - id: "binary"

--- a/api/v1alpha1/repo.go
+++ b/api/v1alpha1/repo.go
@@ -14,6 +14,7 @@ var (
 )
 
 // RepoConfig specifies a repository that should be checked out and periodically sync'd.
+// TODO(jeremy): RepoConfig is a terrible name.
 type RepoConfig struct {
 	APIVersion string   `yaml:"apiVersion"`
 	Kind       string   `yaml:"kind"`

--- a/cmd/commands/apply.go
+++ b/cmd/commands/apply.go
@@ -42,7 +42,7 @@ func NewApplyCmd() *cobra.Command {
 				log.Info("apply takes at least one argument which should be the file or directory YAML to apply.")
 				return
 			}
-
+			logVersion()
 			paths := []string{}
 
 			for _, resourcePath := range args {

--- a/cmd/commands/version.go
+++ b/cmd/commands/version.go
@@ -2,9 +2,10 @@ package commands
 
 import (
 	"fmt"
+	"io"
+
 	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
-	"io"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/commands/version.go
+++ b/cmd/commands/version.go
@@ -1,0 +1,36 @@
+package commands
+
+import (
+	"fmt"
+	"github.com/go-logr/zapr"
+	"go.uber.org/zap"
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+// N.B these will get set by goreleaser
+// https://goreleaser.com/cookbooks/using-main.version/?h=using+main.version
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+	builtBy = "unknown"
+)
+
+func NewVersionCmd(name string, w io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "version",
+		Short:   "Return version",
+		Example: fmt.Sprintf("%s  version", name),
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Fprintf(w, "%s %s, commit %s, built at %s by %s\n", name, version, commit, date, builtBy)
+		},
+	}
+	return cmd
+}
+
+func logVersion() {
+	log := zapr.NewLogger(zap.L())
+	log.Info("binary version", "version", version, "commit", commit, "date", date, "builtBy", builtBy)
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -122,6 +122,7 @@ func init() {
 	rootCmd.AddCommand(commands.NewTakeOverCmd())
 	rootCmd.AddCommand(commands.NewHydrosServerCmd())
 	rootCmd.AddCommand(commands.NewCloneCmd())
+	rootCmd.AddCommand(commands.NewVersionCmd())
 
 	rootCmd.PersistentFlags().BoolVar(&gOptions.devLogger, "dev-logger", false, "If true configure the logger for development; i.e. non-json output")
 	rootCmd.PersistentFlags().StringVarP(&gOptions.level, "log-level", "", "info", "Log level: error info or debug")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -122,7 +122,7 @@ func init() {
 	rootCmd.AddCommand(commands.NewTakeOverCmd())
 	rootCmd.AddCommand(commands.NewHydrosServerCmd())
 	rootCmd.AddCommand(commands.NewCloneCmd())
-	rootCmd.AddCommand(commands.NewVersionCmd())
+	rootCmd.AddCommand(commands.NewVersionCmd("hydros", os.Stdout))
 
 	rootCmd.PersistentFlags().BoolVar(&gOptions.devLogger, "dev-logger", false, "If true configure the logger for development; i.e. non-json output")
 	rootCmd.PersistentFlags().StringVarP(&gOptions.level, "log-level", "", "info", "Log level: error info or debug")

--- a/pkg/gcp/gcb.go
+++ b/pkg/gcp/gcb.go
@@ -55,8 +55,8 @@ func DefaultBuild() *cbpb.Build {
 		Steps: []*cbpb.BuildStep{
 			{
 				Name: kanikoBuilder,
-				// N.B. We don't enable caching by default because that can cause problems.
 				Args: []string{
+					"--cache=true",
 					// Set the date as a build arg
 					// This is so that it can be passed to the builder and used to set the date in the image
 					// of the build

--- a/pkg/gcp/gcb.go
+++ b/pkg/gcp/gcb.go
@@ -55,8 +55,8 @@ func DefaultBuild() *cbpb.Build {
 		Steps: []*cbpb.BuildStep{
 			{
 				Name: kanikoBuilder,
+				// N.B. We don't enable caching by default because that can cause problems.
 				Args: []string{
-					"--cache=true",
 					// Set the date as a build arg
 					// This is so that it can be passed to the builder and used to set the date in the image
 					// of the build

--- a/pkg/github/uris.go
+++ b/pkg/github/uris.go
@@ -1,8 +1,9 @@
 package github
 
 import (
-	"github.com/jlewi/hydros/api/v1alpha1"
 	"net/url"
+
+	"github.com/jlewi/hydros/api/v1alpha1"
 )
 
 // GitHubRepoToURI converts a GitHubRepo to a URI in the gogetter form.

--- a/pkg/github/uris.go
+++ b/pkg/github/uris.go
@@ -1,0 +1,22 @@
+package github
+
+import (
+	"github.com/jlewi/hydros/api/v1alpha1"
+	"net/url"
+)
+
+// GitHubRepoToURI converts a GitHubRepo to a URI in the gogetter form.
+// It assumes the protocol is https.
+func GitHubRepoToURI(repo v1alpha1.GitHubRepo) url.URL {
+	u := url.URL{
+		Scheme: "https",
+		Host:   "github.com",
+		Path:   "/" + repo.Org + "/" + repo.Repo + ".git",
+	}
+
+	if repo.Branch != "" {
+		u.RawQuery = "ref=" + repo.Branch
+	}
+
+	return u
+}

--- a/pkg/github/uris_test.go
+++ b/pkg/github/uris_test.go
@@ -1,0 +1,45 @@
+package github
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"github.com/jlewi/hydros/api/v1alpha1"
+	"net/url"
+	"testing"
+)
+
+func Test_GitHubRepoToURL(t *testing.T) {
+	type testCase struct {
+		name string
+		repo v1alpha1.GitHubRepo
+
+		// Compare the actual URL to one parsed from a string
+		expected string
+	}
+
+	testCases := []testCase{
+		{
+			name: "main",
+			repo: v1alpha1.GitHubRepo{
+				Org:    "jlewi",
+				Repo:   "hydros",
+				Branch: "jlewi/cicd",
+			},
+			expected: "https://github.com/jlewi/hydros.git?ref=jlewi/cicd",
+		},
+	}
+
+	for _, c := range testCases {
+		t.Run(c.name, func(t *testing.T) {
+			actual := GitHubRepoToURI(c.repo)
+
+			expectedU, err := url.Parse(c.expected)
+			if err != nil {
+				t.Fatalf("Error parsing expected URL %v", err)
+			}
+
+			if d := cmp.Diff(expectedU, &actual); d != "" {
+				t.Errorf("Unexpected diff:\n%v", d)
+			}
+		})
+	}
+}

--- a/pkg/github/uris_test.go
+++ b/pkg/github/uris_test.go
@@ -1,10 +1,11 @@
 package github
 
 import (
-	"github.com/google/go-cmp/cmp"
-	"github.com/jlewi/hydros/api/v1alpha1"
 	"net/url"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/jlewi/hydros/api/v1alpha1"
 )
 
 func Test_GitHubRepoToURL(t *testing.T) {

--- a/pkg/gitops/takeover.go
+++ b/pkg/gitops/takeover.go
@@ -1,0 +1,76 @@
+package gitops
+
+import (
+	"context"
+	"github.com/jlewi/hydros/api/v1alpha1"
+	gh "github.com/jlewi/hydros/pkg/github"
+	"github.com/jlewi/hydros/pkg/github/ghrepo"
+	"github.com/jlewi/hydros/pkg/util"
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/url"
+	"time"
+)
+
+// rewriteRepos rewrites the repos in the manifest to the new repos if necessary.
+func rewriteRepos(ctx context.Context, m *v1alpha1.ManifestSync, mappings []v1alpha1.RepoMapping) error {
+	log := util.LogFromContext(ctx)
+
+	if m == nil {
+		return errors.New("Manifest is nil")
+	}
+
+	if mappings == nil {
+		return nil
+	}
+
+	srcRepoURL := gh.GitHubRepoToURI(m.Spec.SourceRepo)
+
+	for _, mapping := range mappings {
+		if srcRepoURL.String() != mapping.Input {
+			continue
+		}
+
+		log.Info("Rewriting source repo", "old", srcRepoURL.String(), "new", mapping.Output, "manifestSync.Name", m.Metadata.Name)
+
+		u, err := url.Parse(mapping.Output)
+		if err != nil {
+			return errors.Wrapf(err, "Could not parse URL %v", mapping.Output)
+		}
+
+		r, err := ghrepo.FromURL(u)
+		if err != nil {
+			return errors.Wrapf(err, "Could not parse URL %v", srcRepoURL.String())
+		}
+
+		// ref parameter specifies the reference to checkout
+		// https://github.com/hashicorp/go-getter#protocol-specific-options
+		branch := u.Query().Get("ref")
+		if branch == "" {
+			return errors.Wrapf(err, "Branch is not specified in URL %v; it should be specified as a query argument e.g. ?ref=main", mapping.Output)
+		}
+		m.Spec.SourceRepo.Org = r.RepoOwner()
+		m.Spec.SourceRepo.Repo = r.RepoName()
+		m.Spec.SourceRepo.Branch = branch
+		return nil
+	}
+	return nil
+}
+
+// SetTakeOverAnnotations sets the takeover annotations on the manifest.
+func SetTakeOverAnnotations(m *v1alpha1.ManifestSync, pause time.Duration) error {
+	tEnd := time.Now().Add(pause)
+
+	k8sTime := metav1.NewTime(tEnd)
+	v, err := k8sTime.MarshalJSON()
+	if err != nil {
+		return errors.Wrapf(err, "Failed to marshal time %v", tEnd)
+	}
+	m.Metadata.Annotations = map[string]string{
+		// We need to mark it as a takeover otherwise we won't override pauses.
+		v1alpha1.TakeoverAnnotation: "true",
+		v1alpha1.PauseAnnotation:    string(v),
+	}
+
+	return nil
+}

--- a/pkg/gitops/takeover.go
+++ b/pkg/gitops/takeover.go
@@ -2,14 +2,15 @@ package gitops
 
 import (
 	"context"
+	"net/url"
+	"time"
+
 	"github.com/jlewi/hydros/api/v1alpha1"
 	gh "github.com/jlewi/hydros/pkg/github"
 	"github.com/jlewi/hydros/pkg/github/ghrepo"
 	"github.com/jlewi/hydros/pkg/util"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"net/url"
-	"time"
 )
 
 // rewriteRepos rewrites the repos in the manifest to the new repos if necessary.

--- a/pkg/gitops/takeover_test.go
+++ b/pkg/gitops/takeover_test.go
@@ -1,0 +1,56 @@
+package gitops
+
+import (
+	"context"
+	"github.com/google/go-cmp/cmp"
+	"github.com/jlewi/hydros/api/v1alpha1"
+	"testing"
+)
+
+func Test_rewriteRepos(t *testing.T) {
+	type testCase struct {
+		name     string
+		manifest *v1alpha1.ManifestSync
+		expected v1alpha1.GitHubRepo
+		mappings []v1alpha1.RepoMapping
+	}
+
+	cases := []testCase{
+		{
+			name: "basic",
+			manifest: &v1alpha1.ManifestSync{
+				Spec: v1alpha1.ManifestSyncSpec{
+					SourceRepo: v1alpha1.GitHubRepo{
+						Org:    "jlewi",
+						Repo:   "hydros",
+						Branch: "main",
+					},
+				},
+			},
+			mappings: []v1alpha1.RepoMapping{
+				{
+					Input:  "https://github.com/jlewi/hydros.git?ref=main",
+					Output: "https://github.com/jlewi/hydros.git?ref=jlewi/cicd",
+				},
+			},
+			expected: v1alpha1.GitHubRepo{
+				Org:    "jlewi",
+				Repo:   "hydros",
+				Branch: "jlewi/cicd",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := rewriteRepos(context.Background(), c.manifest, c.mappings)
+			if err != nil {
+				t.Fatalf("Error rewriting repos: %v", err)
+			}
+
+			if d := cmp.Diff(c.expected, c.manifest.Spec.SourceRepo); d != "" {
+				t.Errorf("Unexpected diff:\n%v", d)
+			}
+		})
+	}
+}

--- a/pkg/gitops/takeover_test.go
+++ b/pkg/gitops/takeover_test.go
@@ -2,9 +2,10 @@ package gitops
 
 import (
 	"context"
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/jlewi/hydros/api/v1alpha1"
-	"testing"
 )
 
 func Test_rewriteRepos(t *testing.T) {

--- a/pkg/tarutil/builder.go
+++ b/pkg/tarutil/builder.go
@@ -163,9 +163,9 @@ func copyTarBall(tw *tar.Writer, s *v1alpha1.ImageSource) error {
 		// Check if any of the patterns match
 		var source *v1alpha1.SourceMapping
 		for _, s := range s.Mappings {
-			isMatch, err := doublestar.Match(s.Src, header.Name)
+			isMatch, err := matchGlobToHeader(s.Src, header.Name)
 			if err != nil {
-				return errors.Wrapf(err, "Error matching glob %v against %v", s.Src, header.Name)
+				return err
 			}
 
 			if isMatch {
@@ -214,6 +214,14 @@ func copyTarBall(tw *tar.Writer, s *v1alpha1.ImageSource) error {
 			return errors.Wrapf(err, "Error reading file contents")
 		}
 	}
+}
+
+func matchGlobToHeader(glob string, headerName string) (bool, error) {
+	// We need to strip the leading / if any from the glob.
+	// https://github.com/jlewi/hydros/issues/69
+	// the paths in the tarball don't have them
+	glob = strings.TrimPrefix(glob, "/")
+	return doublestar.Match(glob, headerName)
 }
 
 // splitIntoParent splits a path into a parent and glob

--- a/pkg/tarutil/builder_test.go
+++ b/pkg/tarutil/builder_test.go
@@ -22,7 +22,7 @@ func Test_Build(t *testing.T) {
 	util.SetupLogger("info", true)
 
 	tDir, err := os.MkdirTemp("", "")
-
+	defer os.RemoveAll(tDir)
 	if err != nil {
 		t.Fatalf("Error creating temp dir %v", err)
 	}
@@ -84,7 +84,7 @@ func Test_Build(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			oFile := filepath.Join(tDir, "test.tar.gz")
+			oFile := filepath.Join(tDir, c.name+" _test.tar.gz")
 			if err := Build(c.source, oFile); err != nil {
 				t.Fatalf("Error building tarball for image %+v", err)
 			}


### PR DESCRIPTION
Per #65 we want to make it easy to use a RepoConfig and deploy from a branch

* Add repo mappings to RepoConfig . This is a set of repo URLs to rewrite the source branches in manifest sync
  this allows the application to be deployed from a branch.
  
* Also add a Pause option which can be used for a takeover.

* Fix #75  when matching globs against paths in a tarball we need to strip any leading "/" in the path.

Add a version command  to hydros
* Update goreleaser to start setting the version