### PR TITLE
Fix a bunch of places where URI is used rather than image; probably a…

### DIFF
--- a/pkg/files/secretmanager.go
+++ b/pkg/files/secretmanager.go
@@ -69,13 +69,13 @@ func (h *GCPSecretManager) NewReader(uri string) (io.Reader, error) {
 
 		if ok {
 			if status.Code() == codes.NotFound {
-				log.Info("No secret exists containing cached token", "secret", secret)
-				return nil, nil
+				log.Info("Secret doesn't exist", "secret", secret)
+				return nil, errors.Errorf("secret %v doesn't exist", secret)
 			}
 
 			if status.Code() == codes.FailedPrecondition {
-				log.Info("Latest version of secret is not valid a new secret will be created.", "secret", secret, "status_message", status.Message())
-				return nil, nil
+				log.Info("here was a problem trying to access the latest version of secret", "secret", secret, "status_message", status.Message())
+				return nil, errors.Errorf("There was a problem trying to access the latest version of secret %v", secret)
 			}
 		}
 		return nil, errors.Wrapf(err, "failed to access secret %v", secret)

--- a/pkg/files/sugar.go
+++ b/pkg/files/sugar.go
@@ -2,6 +2,8 @@ package files
 
 import (
 	"io"
+
+	"github.com/pkg/errors"
 )
 
 // Read reads the given URI
@@ -14,6 +16,9 @@ func Read(uri string) ([]byte, error) {
 	r, err := h.NewReader(uri)
 	if err != nil {
 		return nil, err
+	}
+	if r == nil {
+		return nil, errors.Errorf("no reader was returned for %v", uri)
 	}
 	return io.ReadAll(r)
 }

--- a/pkg/gitops/syncer.go
+++ b/pkg/gitops/syncer.go
@@ -62,7 +62,7 @@ type Syncer struct {
 
 	selector *meta.LabelSelector
 
-	// Cache the Google URI Resolver
+	// Cache the Google image Resolver
 	gcpImageResovler *gcp.ImageResolver
 }
 
@@ -371,7 +371,7 @@ func (s *Syncer) RunOnce(force bool) error {
 		// If the image is built from source then we want to change the tag of the image
 		// to be the source commit
 		if strategy == v1alpha1.SourceCommitStrategy {
-			log.V(util.Debug).Info("URI built from source", "image", source, "oldTag", source.Tag, "newTag", sourceCommit)
+			log.V(util.Debug).Info("image built from source", "image", source, "oldTag", source.Tag, "newTag", sourceCommit)
 			taggedImage.Tag = sourceCommit
 		}
 
@@ -817,7 +817,7 @@ func (s *Syncer) didImagesChange(lastSync []v1alpha1.PinnedImage, current map[ut
 		}
 
 		if lastPinned.ToURL() != newPinned.ToURL() {
-			log.V(util.Debug).Info("URI changed", "mutable", image, "lastPinned", lastPinned, "newPinned", newPinned)
+			log.V(util.Debug).Info("image changed", "mutable", image, "lastPinned", lastPinned, "newPinned", newPinned)
 			changed = append(changed, newPinned)
 		}
 	}
@@ -1139,7 +1139,7 @@ func (s *Syncer) applyKustomizeFns(hydratedPath string, sourceRoot string, files
 }
 
 // TODO(jeremy): Having buildImages as a method on Syncer no longer makes sense.
-// We have the URI resource which should be used to build images. We aren't using skaffold to build images
+// We have the image resource which should be used to build images. We aren't using skaffold to build images
 // so we might just want to delete this code.
 func (s *Syncer) buildImages(sourcePath string, sourceCommit string) error {
 	// Give each run of buildImages a unique id so its easy to group all the messages about image building
@@ -1147,7 +1147,7 @@ func (s *Syncer) buildImages(sourcePath string, sourceCommit string) error {
 	log := s.log.WithValues("skaffoldId", uuid.New().String()[0:5])
 
 	if s.manifest.Spec.ImageBuilder == nil || !s.manifest.Spec.ImageBuilder.Enabled {
-		log.Info("URI builder not enabled")
+		log.Info("image builder not enabled")
 		return nil
 	}
 


### PR DESCRIPTION
* If the GCP secretmanager can't read the secret then NewReader should return an error rather than nil

  * It looks like I had some bad code probably a result of copy pasting whatever code it came from.

* Make files.Read more defensive; check if reader is nil.

* Fix a bunch of places where URI is used rather than image; probably  result of find and replace gone wrong.