### PR TITLE
Fix image build for relative paths.

### DIFF
--- a/pkg/gitutil/gitutil.go
+++ b/pkg/gitutil/gitutil.go
@@ -20,7 +20,14 @@ import (
 
 // LocateRoot locates the root of the git repository at path.
 // Returns empty string if not a git repo.
-func LocateRoot(path string) (string, error) {
+func LocateRoot(origPath string) (string, error) {
+	// If we don't get the absolute path then for a relative path such as "image.yaml" we end up returning "." as the
+	// dir and the loop never terminates
+	path, err := filepath.Abs(origPath)
+	if err != nil {
+		return "", errors.Wrapf(err, "Could not locate git root for %v because the absolute path could not be obtained", origPath)
+
+	}
 	fInfo, err := os.Stat(path)
 	if err != nil {
 		return "", errors.Wrapf(err, "Error stating path %v", path)

--- a/pkg/images/controller.go
+++ b/pkg/images/controller.go
@@ -420,7 +420,7 @@ func ReconcileFile(path string) error {
 		return errors.Wrapf(err, "Failed to open file: %v", manifestPath)
 	}
 
-	gitRoot, err := gitutil.LocateRoot(path)
+	gitRoot, err := gitutil.LocateRoot(manifestPath)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to locate git root for %v", path)
 	}


### PR DESCRIPTION
Fix #73 

* LocateRoot needs to only operate on absolute paths
* Path the absolute path to LocateRoot in the image reconciler; don't use the relative path.