### PR TITLE
Refactor: Rename app package to ghapp

### DIFF
--- a/api/v1alpha1/githubapp.go
+++ b/api/v1alpha1/githubapp.go
@@ -2,9 +2,9 @@ package v1alpha1
 
 // GitHubAppConfig specifies the configuration for a GitHub App.
 type GitHubAppConfig struct {
-	// AppID is the github app id for the app
+	// AppID is the github ghapp id for the ghapp
 	AppID int64 `json:"appID,omitempty" yaml:"appID,omitempty"`
 
-	// PrivateKey is the URI of the private key for the app. This can be a secretmanager URI e.g.
+	// PrivateKey is the URI of the private key for the ghapp. This can be a secretmanager URI e.g.
 	PrivateKey string `json:"privateKey,omitempty" yaml:"privateKey,omitempty"`
 }

--- a/api/v1alpha1/images.go
+++ b/api/v1alpha1/images.go
@@ -70,7 +70,7 @@ type SourceMapping struct {
 	// e.g. "css/**/*.css"
 	Src string `yaml:"src,omitempty"`
 	// Dest is the path to copy the files to in the artifact.
-	// e.g. "app"
+	// e.g. "ghapp"
 	Dest string `yaml:"dest,omitempty"`
 	// Strip is the path prefix to strip from all paths
 	Strip string `yaml:"strip,omitempty"`

--- a/cmd/commands/clone.go
+++ b/cmd/commands/clone.go
@@ -65,7 +65,7 @@ func NewCloneCmd() *cobra.Command {
 	cmd.Flags().StringArrayVarP(&repo, "repo", "", []string{}, "The URLs of the repos to clone.")
 	cmd.Flags().StringVarP(&workDir, "work-dir", "", "", "Directory where repos should be checked out")
 	cmd.Flags().StringVarP(&privateKeyFile, "private-key", "", "", "Path to the file containing the secret for the GitHub App to Authenticate as. Can be stored in gcpSecretManager.")
-	cmd.Flags().Int64VarP(&appID, "app-id", "", 0, "GitHubAppId.")
+	cmd.Flags().Int64VarP(&appID, "ghapp-id", "", 0, "GitHubAppId.")
 
 	return cmd
 }

--- a/cmd/commands/clone_test.go
+++ b/cmd/commands/clone_test.go
@@ -96,7 +96,7 @@ func Test_CloneCmd(t *testing.T) {
 			cmd.SetArgs([]string{
 				"--repo=" + c.repo,
 				"--work-dir=" + tDir,
-				"--app-id=" + fmt.Sprintf("%d", hydrosAppID),
+				"--ghapp-id=" + fmt.Sprintf("%d", hydrosAppID),
 				"--private-key=" + hydrosKey,
 			})
 			if err := cmd.Execute(); err != nil {

--- a/cmd/commands/takeover.go
+++ b/cmd/commands/takeover.go
@@ -47,7 +47,7 @@ func NewTakeOverCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&opts.WorkDir, "work-dir", "", "", "Directory where repos should be checked out")
 	cmd.Flags().StringVarP(&opts.Secret, "private-key", "", "", "Path to the file containing the secret for the GitHub App to Authenticate as.")
-	cmd.Flags().Int64VarP(&opts.GithubAppID, "app-id", "", hydros.HydrosGitHubAppID, "GitHubAppId.")
+	cmd.Flags().Int64VarP(&opts.GithubAppID, "ghapp-id", "", hydros.HydrosGitHubAppID, "GitHubAppId.")
 	cmd.Flags().BoolVarP(&opts.Force, "force", "", false, "Force a sync even if one isn't needed.")
 	cmd.Flags().StringVarP(&opts.File, "file", "", "", "The file containing the configuration to apply.")
 	cmd.Flags().StringVarP(&opts.KeyFile, "ssh-key-file", "", "", "(Optional) Path of PEM file containing ssh key used to push current changes. If blank will try to find key in ${HOME}/.ssh.")

--- a/cmd/github/commands.go
+++ b/cmd/github/commands.go
@@ -24,8 +24,8 @@ func NewAppTokenCmd(w io.Writer, level *string, devLogger *bool) *cobra.Command 
 	var envFile string
 
 	cmd := &cobra.Command{
-		Use:   "github-app-token",
-		Short: "Get a github app authorization token.",
+		Use:   "github-ghapp-token",
+		Short: "Get a github ghapp authorization token.",
 		Run: func(cmd *cobra.Command, args []string) {
 			log := util.SetupLogger(*level, *devLogger)
 			err := func() error {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -79,7 +79,7 @@ var (
 					log.Error(err, "Failed to add tags to image", "image", tOptions.image, "tags", tags)
 				}
 			} else {
-				// TOOD(jeremy): We should use github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/flags
+				// TOOD(jeremy): We should use github.com/GoogleContainerTools/skaffold/cmd/skaffold/ghapp/flags
 				type Build struct {
 					ImageName string `yaml:"imageName,omitempty"`
 					Tag       string `yaml:"tag,omitempty"`

--- a/docs/design_declarative_cd.md
+++ b/docs/design_declarative_cd.md
@@ -62,7 +62,7 @@ this can be achieved by continuing to support `hydros apply` and `hydros takeove
 
 ### GitHub App
 
-Makeing hydros a GitHub App is something we'd previously explored. Some of the code is in [../pkg/app](../pkg/app).
+Makeing hydros a GitHub App is something we'd previously explored. Some of the code is in [../pkg/app](../pkg/ghapp).
 
 There were a bunch of different problems we were potentially trying to solve by making it a GitHub App
 

--- a/docs/takeover.md
+++ b/docs/takeover.md
@@ -14,7 +14,7 @@ Hydros supports taking over dev using the CLI. This works as follows
    ```bash
     hydros takeover \
       --file=<path/to/your/manifestsync.yaml> \
-      --app-id=<GitHubAppID for Hydros> \
+      --ghapp-id=<GitHubAppID for Hydros> \
       --work-dir=<Local directory for Hydros to clone repositories> \
       --private-key=<Path to the GitHubApp Private Key; use gcpSecretManager:/// to use a GCP Secrete Manager S>
    ```

--- a/images.yaml
+++ b/images.yaml
@@ -19,8 +19,8 @@ spec:
     # Pull in kustomize from its docker image
     - uri: docker://registry.k8s.io/kustomize/kustomize:v5.0.0
       mappings:
-        - src: app/kustomize
-          strip: app
+        - src: ghapp/kustomize
+          strip: ghapp
   builder:
     gcb:
       project: foyle-public

--- a/manifests/lewi/httproute.yaml
+++ b/manifests/lewi/httproute.yaml
@@ -9,7 +9,7 @@ spec:
       name: platform
       namespace: gateway
   hostnames:
-    - "platform.roboweb.app"
+    - "platform.roboweb.ghapp"
   rules:
     - matches:
       # As extra security precaution only expose very specific routes

--- a/pkg/app/doc.go
+++ b/pkg/app/doc.go
@@ -1,2 +1,0 @@
-// Package app defines the actual HTTP application that handles webhooks for the GitHub App.
-package app

--- a/pkg/ghapp/config.go
+++ b/pkg/ghapp/config.go
@@ -1,4 +1,4 @@
-package app
+package ghapp
 
 import (
 	"github.com/jlewi/hydros/pkg/files"

--- a/pkg/ghapp/doc.go
+++ b/pkg/ghapp/doc.go
@@ -1,0 +1,2 @@
+// Package ghapp defines the actual HTTP application that handles webhooks for the GitHub App.
+package ghapp

--- a/pkg/ghapp/fetcher.go
+++ b/pkg/ghapp/fetcher.go
@@ -1,4 +1,4 @@
-package app
+package ghapp
 
 import (
 	"context"

--- a/pkg/ghapp/handler.go
+++ b/pkg/ghapp/handler.go
@@ -1,4 +1,4 @@
-package app
+package ghapp
 
 import (
 	"bytes"

--- a/pkg/ghapp/handler_test.go
+++ b/pkg/ghapp/handler_test.go
@@ -1,4 +1,4 @@
-package app
+package ghapp
 
 import (
 	"context"

--- a/pkg/ghapp/server.go
+++ b/pkg/ghapp/server.go
@@ -1,4 +1,4 @@
-package app
+package ghapp
 
 import (
 	"context"

--- a/pkg/github/clone.go
+++ b/pkg/github/clone.go
@@ -18,7 +18,7 @@ import (
 // ReposCloner clones a set of repositories
 //
 // TODO(jeremy): This is currently GitHub specific we should change that
-// TODO(jeremy): How do we support public repositories? right now it always uses the app auth.
+// TODO(jeremy): How do we support public repositories? right now it always uses the ghapp auth.
 type ReposCloner struct {
 	// List of repositories to clone
 	URIs    []string

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -66,9 +66,9 @@ func newOrgAndRepo(org string, repo string) orgAndRepo {
 }
 
 // TransportManager manages transport managers for a GitHub App.
-// The manager is instantiated with the app ID and private key for a GitHub App.
+// The manager is instantiated with the ghapp ID and private key for a GitHub App.
 // The Get function can then be used to obtain a transport with credentials to talk to a particular repository
-// that the app has access to
+// that the ghapp has access to
 //
 // TODO(jeremy): Can/should we wrap this in the OAuth flow.
 // TODO(jeremy): Should we reuse some of palantir built?
@@ -123,7 +123,7 @@ func (m *TransportManager) Get(org string, repo string) (*ghinstallation.Transpo
 	// Shared transport to reuse TCP connections.
 	tr := http.DefaultTransport
 
-	// Wrap the shared transport for use with the app ID 1 authenticating with installation ID 99.
+	// Wrap the shared transport for use with the ghapp ID 1 authenticating with installation ID 99.
 	ghTr, err := ghinstallation.New(tr, m.appID, gitHubInstallID, m.privateKey)
 	if err != nil {
 		log.Error(err, "Failed to Get GitHub App Transport", "AppId", m.appID, "Org", org, "Repo", repo)

--- a/pkg/github/proxy.go
+++ b/pkg/github/proxy.go
@@ -15,7 +15,7 @@ import (
 	ddMux "gopkg.in/DataDog/dd-trace-go.v1/contrib/gorilla/mux"
 )
 
-// Proxy is a proxy server for GitHub. It proxies http requests using a GitHub app's credentials. This
+// Proxy is a proxy server for GitHub. It proxies http requests using a GitHub ghapp's credentials. This
 // makes it easy to fetch documents from private repositories.
 //
 // N.B jeremy@ tried using the gin framework but couldn't figure out how to properly handle path prefixes.

--- a/pkg/gitops/renderer.go
+++ b/pkg/gitops/renderer.go
@@ -117,7 +117,7 @@ func (r *Renderer) Run(anyEvent any) error {
 	// CreateCheckRun requires a commit in order to attach a run to.
 	// N.B. There is a bit of a race condition here. We risk reporting
 	// the run as queued when it isn't actually because we crash before calling enqueue. However, its always
-	// possible that the app crashes after it was enqueued but before it succeeds. That should eventually be handled
+	// possible that the ghapp crashes after it was enqueued but before it succeeds. That should eventually be handled
 	// by appropriate level based semantics. If we don't call CreateCheckRun we won't know the
 	check, response, err := r.client.Checks.CreateCheckRun(context.Background(), r.org, r.repo, ghAPI.CreateCheckRunOptions{
 		Name:       RendererCheckName,
@@ -398,7 +398,7 @@ func (r *Renderer) syncNeeded() (bool, error) {
 	}
 
 	// N.B. This is a bit of a hack but couldn't figure out a better way. The email and name don't appear
-	// to be what is set in the git config.  I think it depends on the values set in the GitHub app.
+	// to be what is set in the git config.  I think it depends on the values set in the GitHub ghapp.
 	if strings.HasPrefix(commit.Author.Name, "hydros") {
 		log.Info("Last commit was made by hydros AI; skipping sync", "name", commit.Author.Name, "email", commit.Author.Email, "commit", commit.Hash.String())
 		return false, nil

--- a/pkg/gitops/syncer.go
+++ b/pkg/gitops/syncer.go
@@ -126,11 +126,11 @@ func NewSyncer(m *v1alpha1.ManifestSync, manager *github.TransportManager, opts 
 		s.selector = selector
 	}
 
-	// Ensure we can get transports for each repo; this basically verifies the app is authorized
+	// Ensure we can get transports for each repo; this basically verifies the ghapp is authorized
 	// for each repo.
 	for _, repo := range getRepos(*s.manifest) {
 		if _, err := s.transports.Get(repo.Org, repo.Repo); err != nil {
-			return nil, errors.Wrapf(err, "Failed to get transport for repo %v/%v; Is the GitHub app installed in that repo?", repo.Org, repo.Repo)
+			return nil, errors.Wrapf(err, "Failed to get transport for repo %v/%v; Is the GitHub ghapp installed in that repo?", repo.Org, repo.Repo)
 		}
 	}
 
@@ -138,7 +138,7 @@ func NewSyncer(m *v1alpha1.ManifestSync, manager *github.TransportManager, opts 
 	dRepo := s.manifest.Spec.DestRepo
 	tr, err := s.transports.Get(dRepo.Org, dRepo.Repo)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to get transport for repo %v/%v; Is the GitHub app installed in that repo?", dRepo.Org, dRepo.Repo)
+		return nil, errors.Wrapf(err, "Failed to get transport for repo %v/%v; Is the GitHub ghapp installed in that repo?", dRepo.Org, dRepo.Repo)
 	}
 
 	args := &github.RepoHelperArgs{

--- a/pkg/hydros/constants.go
+++ b/pkg/hydros/constants.go
@@ -1,6 +1,6 @@
 package hydros
 
 const (
-	// HydrosGitHubAppID is the app id for Hydros.
+	// HydrosGitHubAppID is the ghapp id for Hydros.
 	HydrosGitHubAppID = 266158
 )

--- a/pkg/kustomize/fns/configmap/wrapper_test.go
+++ b/pkg/kustomize/fns/configmap/wrapper_test.go
@@ -33,7 +33,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: gateway
+      ghapp: gateway
       mlp-tenant: automl-1
 `,
 			},
@@ -51,7 +51,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: gateway
+      ghapp: gateway
       mlp-tenant: automl-1
 `,
 			},

--- a/pkg/kustomize/fns/fields/fields_test.go
+++ b/pkg/kustomize/fns/fields/fields_test.go
@@ -35,7 +35,7 @@ spec:
         keytoremove: someothervalue
     spec:
       containers:
-      - name: app
+      - name: ghapp
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -70,7 +70,7 @@ spec:
         keytoremove: someothervalue
     spec:
       containers:
-      - name: app
+      - name: ghapp
 `,
 			filter: Fields{
 				Metadata: v1alpha1.Metadata{
@@ -97,7 +97,7 @@ spec:
  template:
    spec:
      containers:
-     - name: app
+     - name: ghapp
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
@@ -130,7 +130,7 @@ spec:
  template:
    spec:
      containers:
-     - name: app
+     - name: ghapp
      tolerations:
      - effect: NoSchedule
        key: instancetype

--- a/pkg/kustomize/fns/labels/function_test.go
+++ b/pkg/kustomize/fns/labels/function_test.go
@@ -34,7 +34,7 @@ spec:
         keytoremove: someothervalue
     spec:
       containers:
-      - name: app
+      - name: ghapp
 `,
 			expectedOutput: `
 apiVersion: v1
@@ -51,7 +51,7 @@ spec:
         newlabel: newvalue
     spec:
       containers:
-      - name: app
+      - name: ghapp
 `,
 			filter: CommonLabelsFn{
 				Metadata: v1alpha1.Metadata{
@@ -114,7 +114,7 @@ spec:
   template:
     spec:
       containers:
-      - name: app
+      - name: ghapp
 `,
 			expectedOutput: `
 apiVersion: v1
@@ -127,7 +127,7 @@ spec:
   template:
     spec:
       containers:
-      - name: app
+      - name: ghapp
 `,
 			filter: CommonLabelsFn{
 				Metadata: v1alpha1.Metadata{

--- a/pkg/skaffold/config.go
+++ b/pkg/skaffold/config.go
@@ -775,7 +775,7 @@ type SyncRule struct {
 	Src string `yaml:"src,omitempty" yamltags:"required"`
 
 	// Dest is the destination path in the container where the files should be synced to.
-	// For example: `"app/"`
+	// For example: `"ghapp/"`
 	Dest string `yaml:"dest,omitempty" yamltags:"required"`
 
 	// Strip specifies the path prefix to remove from the source path when
@@ -1203,7 +1203,7 @@ type KoArtifact struct {
 	// Dir is the directory where the `go` tool will be run.
 	// The value is a directory path relative to the `context` directory.
 	// If empty, the `go` tool will run in the `context` directory.
-	// Example: `./my-app-sources`.
+	// Example: `./my-ghapp-sources`.
 	Dir string `yaml:"dir,omitempty"`
 
 	// Env are environment variables, in the `key=value` form, passed to the build.

--- a/pkg/tarutil/builder_test.go
+++ b/pkg/tarutil/builder_test.go
@@ -164,30 +164,30 @@ func Test_matchGlob(t *testing.T) {
 	cases := []testCase{
 		{
 			files: []string{
-				"pkg/ghapp/ghapp.go",
-				"pkg/ghapp/text.tmpl",
+				"pkg/app/app.go",
+				"pkg/app/text.tmpl",
 			},
 			glob: "**/*",
 			expected: []string{
 				"pkg",
-				"pkg/ghapp",
-				"pkg/ghapp/ghapp.go",
-				"pkg/ghapp/text.tmpl",
+				"pkg/app",
+				"pkg/app/app.go",
+				"pkg/app/text.tmpl",
 			},
 		},
 		// Test ".." in a pattern
 		{
 			files: []string{
-				"pkg/ghapp/ghapp.go",
-				"pkg/ghapp/text.tmpl",
+				"pkg/app/app.go",
+				"pkg/app/text.tmpl",
 				"pkg/b/file2.go",
 			},
 			glob: "pkg/b/../**/*",
 			expected: []string{
-				"pkg/ghapp",
+				"pkg/app",
 				"pkg/b",
-				"pkg/ghapp/ghapp.go",
-				"pkg/ghapp/text.tmpl",
+				"pkg/app/app.go",
+				"pkg/app/text.tmpl",
 				"pkg/b/file2.go",
 			},
 		},
@@ -270,19 +270,19 @@ func Test_matchGlobToHeader(t *testing.T) {
 		{
 			name:    "basic",
 			glob:    "pkg/**/*.go",
-			header:  "pkg/ghapp.go",
+			header:  "pkg/app.go",
 			isMatch: true,
 		},
 		{
 			name:    "glob-has-leading-slash",
 			glob:    "/pkg/**/*.go",
-			header:  "pkg/ghapp.go",
+			header:  "pkg/app.go",
 			isMatch: true,
 		},
 		{
 			name:    "not-a-match",
 			glob:    "/pkg/**/*.go",
-			header:  "ghapp.go",
+			header:  "app.go",
 			isMatch: false,
 		},
 	}

--- a/pkg/tarutil/builder_test.go
+++ b/pkg/tarutil/builder_test.go
@@ -164,30 +164,30 @@ func Test_matchGlob(t *testing.T) {
 	cases := []testCase{
 		{
 			files: []string{
-				"pkg/app/app.go",
-				"pkg/app/text.tmpl",
+				"pkg/ghapp/ghapp.go",
+				"pkg/ghapp/text.tmpl",
 			},
 			glob: "**/*",
 			expected: []string{
 				"pkg",
-				"pkg/app",
-				"pkg/app/app.go",
-				"pkg/app/text.tmpl",
+				"pkg/ghapp",
+				"pkg/ghapp/ghapp.go",
+				"pkg/ghapp/text.tmpl",
 			},
 		},
 		// Test ".." in a pattern
 		{
 			files: []string{
-				"pkg/app/app.go",
-				"pkg/app/text.tmpl",
+				"pkg/ghapp/ghapp.go",
+				"pkg/ghapp/text.tmpl",
 				"pkg/b/file2.go",
 			},
 			glob: "pkg/b/../**/*",
 			expected: []string{
-				"pkg/app",
+				"pkg/ghapp",
 				"pkg/b",
-				"pkg/app/app.go",
-				"pkg/app/text.tmpl",
+				"pkg/ghapp/ghapp.go",
+				"pkg/ghapp/text.tmpl",
 				"pkg/b/file2.go",
 			},
 		},
@@ -270,19 +270,19 @@ func Test_matchGlobToHeader(t *testing.T) {
 		{
 			name:    "basic",
 			glob:    "pkg/**/*.go",
-			header:  "pkg/app.go",
+			header:  "pkg/ghapp.go",
 			isMatch: true,
 		},
 		{
 			name:    "glob-has-leading-slash",
 			glob:    "/pkg/**/*.go",
-			header:  "pkg/app.go",
+			header:  "pkg/ghapp.go",
 			isMatch: true,
 		},
 		{
 			name:    "not-a-match",
 			glob:    "/pkg/**/*.go",
-			header:  "app.go",
+			header:  "ghapp.go",
 			isMatch: false,
 		},
 	}


### PR DESCRIPTION
The app package contains code for a GitHub App

* Per https://github.com/jlewi/hydros/blob/main/docs/design_declarative_cd.md#github-app and #5 I don't think we will use most of this

* We'd like to have an App class to encapsulate all of hydros.
* So we rename the app package so we can keep the code until we clean it up.