### PR TITLE
GitHubReleaser resource 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ lint: lint-go
 test-go: test
 
 test:	
-	go test -v ./...
+	GITHUB_ACTIONS=true go test -v ./...
 
 
 # Build with ko

--- a/README.md
+++ b/README.md
@@ -1,6 +1,21 @@
 # hydros
 
-Hydros is a bot that hydrates manifests and opens a PR to check in hydrated manifests.
+Hydros is a tools for continuous delivery. Hydros brings a declarative mindset to continuous delivery.
+Rather than use a DAG to imperatively define a delivery pipeline, hyrdros consists of a collection of resources.
+Each resource is a declarative definition of one or more delivery artifacts. Here are some examples of the semantics,
+ 
+* [Image](docs/image_build.md) resource -  **Ensure there is an image built from the latest commit of the source repository**.
+* [ManifestSync](docs/hydrating_manifests.md) resource -  **Ensure hydrated manifests for the latest commit of the source repository are checked into the hydrated repository**.
+* [GitHubReleaser](docs/github_releaser.md) resource - **Ensure a GitHub release exists for the latest commit in the repository**.
+
+Each resource is backed by a controller baked into the hydros binary. A resource is reconciled by applying it using
+the CLI
+
+```bash
+hydros apply  <resource.yaml>
+```
+
+For more information see the [docs](docs)
 
 # Open Source Project Status
 
@@ -8,11 +23,6 @@ Hydros is a bot that hydrates manifests and opens a PR to check in hydrated mani
 * Issues: appreciated but unfortunately we don't have the bandwidth to respond in a timely fashion
 * PRs: appreciated but unfortunately we don't have the bandwidth to respond in a timely fashion
 
-Primer is open sourcing hydros in order to foster discussions with the kustomize and GitOps
-communities about potential areas of collaboration.
-
-At this point in time, hydros is unlikely to work out of box for anyone outside of Primer
-as it makes several decisions specific to how Primer does CI/CD.
 
 # Documentation
 
@@ -25,3 +35,6 @@ There are two binaries currently being built out of this repository
 * hydros - This is the main binary in this repository
 * sanitizer - This is a utility to help sanitize internal code before publishing it as public open source. It was
    initially developed to aid in open sourcing hydros. It was inspired by a similar tool used at Google.
+
+# Releasing
+

--- a/api/v1alpha1/releaser.go
+++ b/api/v1alpha1/releaser.go
@@ -1,0 +1,16 @@
+package v1alpha1
+
+// GitHubReleaser continuously cuts GitHub releases when conditions are
+// met. It takes care of setting the release notes and the version.
+type GitHubReleaser struct {
+	APIVersion string             `yaml:"apiVersion" yamltags:"required"`
+	Kind       string             `yaml:"kind" yamltags:"required"`
+	Metadata   Metadata           `yaml:"metadata,omitempty"`
+	Spec       GitHubReleaserSpec `yaml:"spec,omitempty"`
+}
+
+type GitHubReleaserSpec struct {
+	Org string `yaml:"org,omitempty"`
+	// Repo is the repository to release
+	Repo string `yaml:"repo,omitempty"`
+}

--- a/api/v1alpha1/releaser.go
+++ b/api/v1alpha1/releaser.go
@@ -13,4 +13,6 @@ type GitHubReleaserSpec struct {
 	Org string `yaml:"org,omitempty"`
 	// Repo is the repository to release
 	Repo string `yaml:"repo,omitempty"`
+
+	// TODO(jeremy): We should probably support branch
 }

--- a/api/v1alpha1/releaser.go
+++ b/api/v1alpha1/releaser.go
@@ -1,5 +1,11 @@
 package v1alpha1
 
+import "k8s.io/apimachinery/pkg/runtime/schema"
+
+var (
+	GitHubReleaserGVK = schema.FromAPIVersionAndKind(Group+"/"+Version, "GitHubReleaser")
+)
+
 // GitHubReleaser continuously cuts GitHub releases when conditions are
 // met. It takes care of setting the release notes and the version.
 type GitHubReleaser struct {

--- a/api/v1alpha1/repo.go
+++ b/api/v1alpha1/repo.go
@@ -29,6 +29,8 @@ type RepoSpec struct {
 	// https://github.com/hashicorp/go-getter#protocol-specific-options
 	Repo string `yaml:"repo"`
 	// GitHubAppConfig is the configuration for the GitHub App to use to access the repo.
+	// TODO(jeremy): Can we deprecate this? Now that Hydros supports providing this as part of the cobra configuration
+	// Do we need to put this in the individual repo configs?
 	GitHubAppConfig GitHubAppConfig `yaml:"gitHubAppConfig"`
 
 	// Globs is a list of globs to search for resources to sync.

--- a/api/v1alpha1/repo.go
+++ b/api/v1alpha1/repo.go
@@ -28,10 +28,6 @@ type RepoSpec struct {
 	// You can specify a branch using the ref parameter specifies the reference to checkout
 	// https://github.com/hashicorp/go-getter#protocol-specific-options
 	Repo string `yaml:"repo"`
-	// GitHubAppConfig is the configuration for the GitHub App to use to access the repo.
-	// TODO(jeremy): Can we deprecate this? Now that Hydros supports providing this as part of the cobra configuration
-	// Do we need to put this in the individual repo configs?
-	GitHubAppConfig GitHubAppConfig `yaml:"gitHubAppConfig"`
 
 	// Globs is a list of globs to search for resources to sync.
 	Globs []string `yaml:"globs,omitempty"`
@@ -70,14 +66,6 @@ func (c *RepoConfig) IsValid() (string, bool) {
 	if !strings.HasPrefix(c.Spec.Repo, "https://") {
 		// We use https because we are using a GitHub App
 		errors = append(errors, "Repo must be an https URL; currently only https is supported for cloning repositories")
-	}
-
-	if c.Spec.GitHubAppConfig.AppID == 0 {
-		errors = append(errors, "GitHubAppConfig.AppID must be specified and non-zero")
-	}
-
-	if c.Spec.GitHubAppConfig.PrivateKey == "" {
-		errors = append(errors, "GitHubAppConfig.PrivateKey is required")
 	}
 
 	if len(c.Spec.Globs) == 0 {

--- a/docs/continuous_delivery.md
+++ b/docs/continuous_delivery.md
@@ -7,7 +7,34 @@ How to use hydros to continuously deliver a set of resources to a kubernetes clu
 ## Configuring continuous delivery
 
 You configure continuous delivery for your application by defining resources corresponding to the artifacts
-that need to be continuously delivered.
+that need to be continuously delivered. A release is defined by two parts
+
+1. A RepoConfig resource that defines the source repository and branch to look for resource definitions
+2. A collection of resources that need to be continuously delivered see next section for more information on the resources
+
+Here is an example of a RepoConfig resource
+
+```yaml
+apiVersion: hydros.dev/v1alpha1
+kind: RepoConfig
+metadata:
+  name: repo
+  namespace: hydros
+spec:
+  repo: https://github.com/yourrepo/code.git  
+  globs:
+    - "**/*.yaml"
+  selectors:
+    - matchLabels:
+        env: dev
+```
+
+When you apply this resource using hydros, hydros does the following
+
+1. It clones the repository and branch specified in the repo field
+2. It looks for files matching the glob expressions in the globs field
+3. It reads the resources from the files and applies the selector to determine which resources to reconcile
+4. It reconciles the matching resources
 
 ### Images
 
@@ -79,3 +106,12 @@ continuously run reconciliation, you can use the `--period` flag to specify an i
 ```bash
 hydros apply --work-dir=/tmp/hydros --dev-logger=true /path/to/your/repo_config.yaml --period=5m
 ```
+
+## Developing and Testing New Workflows
+
+When developing new workflows, you can test your changes without merging them to main first as follows
+
+1. Create a new branch in your repository
+2. Update your `RepoConfig` resource to point to the new branch
+3. Push your changes to GitHub
+4. Run `hydros apply` on the `RepoConfig` resource

--- a/docs/continuous_delivery.md
+++ b/docs/continuous_delivery.md
@@ -62,9 +62,6 @@ metadata:
   namespace: hydros
 spec:
   repo: https://github.com/yourrepo/code.git
-  gitHubAppConfig:
-    appID: 384797
-    privateKey: gcpsecretmanager:///projects/YOURPROJECT/secrets/hydros-ghapp-key/versions/latest
   globs:
     - "**/*.yaml"
   selectors:

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -6,3 +6,11 @@
         * Pull Requests - Read & Write
 2. Generate a private key for the github app
 3. Install it on the repositories that will be used as the source and destination
+4. Download the latest hydros release from the [releases page](https://github.com/jlewi/hydros/releases)
+5. Install the hydros binary on your system
+6. Configure hydros to use the github app
+ 
+   ```bash
+   hydros config set github.appID=<YOUR GitHub App ID>
+   hydros config set github.privateKey=/path/to/your/secret/key
+   ```

--- a/images.yaml
+++ b/images.yaml
@@ -3,6 +3,8 @@ apiVersion: hydros.dev/v1alpha1
 metadata:
   name: hydros
   namespace: hydros
+  labels:
+    env: release
 spec:
   image: us-west1-docker.pkg.dev/foyle-public/images/hydros/hydros
   source:

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -202,7 +202,7 @@ func (a *App) apply(ctx context.Context, path string, syncNames map[string]strin
 				continue
 			}
 
-			c, err := gitops.NewRepoController(repo, a.Config.GetWorkDir())
+			c, err := gitops.NewRepoController(*a.Config, repo)
 			if err != nil {
 				return err
 			}

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -3,12 +3,13 @@ package github
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+
 	"github.com/go-logr/zapr"
 	"github.com/jlewi/hydros/pkg/config"
 	"github.com/jlewi/hydros/pkg/files"
 	"go.uber.org/zap"
-	"io"
-	"net/http"
 
 	ghinstallation "github.com/bradleyfalzon/ghinstallation/v2"
 	"github.com/go-logr/logr"

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -3,6 +3,10 @@ package github
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/go-logr/zapr"
+	"github.com/jlewi/hydros/pkg/config"
+	"github.com/jlewi/hydros/pkg/files"
+	"go.uber.org/zap"
 	"io"
 	"net/http"
 
@@ -80,6 +84,15 @@ type TransportManager struct {
 
 	// Map of orgAndRepo to the transport to talk to that Repo.
 	ghTransports map[orgAndRepo]*ghinstallation.Transport
+}
+
+// NewTransportManagerFromConfig creates a new transport manager from the specified configuration.
+func NewTransportManagerFromConfig(cfg config.Config) (*TransportManager, error) {
+	privateKey, err := files.Read(cfg.GitHub.PrivateKey)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Could not create GitHub transport manager; failed to read key: %s", cfg.GitHub.PrivateKey)
+	}
+	return NewTransportManager(cfg.GitHub.AppID, privateKey, zapr.NewLogger(zap.L()))
 }
 
 // NewTransportManager creates a new transport manager.

--- a/pkg/github/releaser.go
+++ b/pkg/github/releaser.go
@@ -1,0 +1,189 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"github.com/go-logr/zapr"
+	"github.com/google/go-github/v52/github"
+	"github.com/jlewi/hydros/api/v1alpha1"
+	"github.com/jlewi/hydros/pkg/config"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+	"golang.org/x/mod/semver"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// Releaser creates github releases if needed.
+type Releaser struct {
+	Transports *TransportManager
+}
+
+func NewReleaser(cfg config.Config) (*Releaser, error) {
+	t, err := NewTransportManagerFromConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &Releaser{
+		Transports: t,
+	}, nil
+}
+
+func (r *Releaser) Reconcile(ctx context.Context, resource *v1alpha1.GitHubReleaser) error {
+	log := zapr.NewLogger(zap.L())
+	log = log.WithValues("namespace", resource.Metadata.Namespace, "name", resource.Metadata.Name)
+	org := resource.Spec.Org
+	repo := resource.Spec.Repo
+
+	client, err := createClient(r.Transports, org, repo)
+	if err != nil {
+		return err
+	}
+
+	// Get the latest commit on the repository
+	latestCommit, err := getLatestCommit(ctx, client, org, repo)
+	if err != nil {
+		return err
+	}
+	log.Info("Got latest commit", "sha", latestCommit.GetSHA())
+
+	latestSrc, latestReleaseCommit, err := getLatestRelease(ctx, client, org, repo)
+	if err != nil {
+		return err
+	}
+
+	if latestReleaseCommit == nil {
+		log.Info("No releases found; creating first release")
+	}
+	// Check if the latest release on the source repository is the same as the latest commit
+	// If not create a new release
+	if latestReleaseCommit == nil || latestCommit.GetSHA() != latestReleaseCommit.GetSHA() {
+		newRelease, err := createNewRelease(ctx, client, org, repo, latestSrc, latestCommit)
+		if err != nil {
+			return err
+		}
+		latestSrc = newRelease
+	}
+
+	return nil
+}
+
+// createNewRelease creates a new release if lastRelease is nil then it creates the first release
+func createNewRelease(ctx context.Context, client *github.Client, org string, repo string, lastRelease *github.RepositoryRelease, commit *github.RepositoryCommit) (*github.RepositoryRelease, error) {
+	log := zapr.NewLogger(zap.L())
+
+	// Convention is to prefix with v
+	newTag := "v0.0.1"
+
+	if lastRelease != nil {
+		pieces := strings.Split(lastRelease.GetTagName(), ".")
+		minor := pieces[len(pieces)-1]
+		minorInt, err := strconv.Atoi(minor)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Error parsing minor version %v", minor)
+		}
+		pieces[len(pieces)-1] = fmt.Sprintf("%d", minorInt+1)
+		newTag = strings.Join(pieces, ".")
+	}
+
+	notes, _, err := client.Repositories.GenerateReleaseNotes(ctx, org, repo, &github.GenerateNotesOptions{
+		TagName:         newTag,
+		PreviousTagName: github.String(lastRelease.GetTagName()),
+		TargetCommitish: github.String(commit.GetSHA()),
+	})
+
+	if err != nil {
+		return nil, errors.Wrapf(err, "Error generating release notes")
+	}
+
+	log.Info("Creating release", "name", newTag, "tag", newTag, "notes", notes)
+	// Create the release
+	newRelease := &github.RepositoryRelease{
+		Name:       github.String(notes.Name),
+		TagName:    github.String(newTag),
+		Body:       github.String(notes.Body),
+		Prerelease: github.Bool(false),
+		Draft:      github.Bool(false),
+		MakeLatest: github.String("true"),
+	}
+	newRelease, _, err = client.Repositories.CreateRelease(ctx, org, repo, newRelease)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Error creating release %v", newRelease.GetTagName())
+	}
+
+	return newRelease, nil
+}
+
+func getLatestCommit(ctx context.Context, client *github.Client, org string, repo string) (*github.RepositoryCommit, error) {
+	commit, _, err := client.Repositories.GetCommit(ctx, org, repo, "heads/main", &github.ListOptions{})
+
+	if err != nil {
+		return nil, errors.Wrapf(err, "Error getting commit")
+	}
+
+	return commit, nil
+}
+
+// getLatestRelease returns the latest release for the repository or nil if there isn't one
+func getLatestRelease(ctx context.Context, client *github.Client, org string, repo string) (*github.RepositoryRelease, *github.RepositoryCommit, error) {
+	releases, _, err := client.Repositories.ListReleases(ctx, org, repo, nil)
+
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "Error listing releases")
+	}
+
+	if len(releases) == 0 {
+		return nil, nil, nil
+	}
+
+	var latestRelease *github.RepositoryRelease
+	for _, release := range releases {
+		// Skip draft and and prerelease releases
+		if release.GetDraft() {
+			continue
+		}
+		if release.GetPrerelease() {
+			continue
+		}
+
+		if !semver.IsValid(release.GetTagName()) {
+			continue
+		}
+
+		if latestRelease == nil {
+			latestRelease = release
+			continue
+		}
+
+		if semver.Compare(release.GetTagName(), latestRelease.GetTagName()) > 0 {
+			latestRelease = release
+		}
+	}
+
+	if latestRelease == nil {
+		return latestRelease, nil, errors.Errorf("Could not find latest release")
+	}
+
+	releaseCommit, _, err := client.Repositories.GetCommit(ctx, org, repo, "tags/"+latestRelease.GetTagName(), &github.ListOptions{})
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "Error getting commit for release %v", latestRelease.GetTagName())
+	}
+
+	log := zapr.NewLogger(zap.L())
+	log.Info("Latest release", "name", latestRelease.GetName(), "Assets URL", latestRelease.GetAssetsURL(), "commit", releaseCommit.GetSHA())
+	return latestRelease, releaseCommit, nil
+}
+
+func createClient(transports *TransportManager, org string, repo string) (*github.Client, error) {
+	tr, err := transports.Get(org, repo)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Could not get transport for %v/%v", org, repo)
+	}
+
+	httpClient := &http.Client{
+		Transport: tr,
+	}
+	client := github.NewClient(httpClient)
+	return client, nil
+}

--- a/pkg/github/releaser_test.go
+++ b/pkg/github/releaser_test.go
@@ -1,0 +1,48 @@
+package github
+
+import (
+	"context"
+	"github.com/jlewi/hydros/api/v1alpha1"
+	"github.com/jlewi/hydros/pkg/config"
+	"go.uber.org/zap"
+	"os"
+	"testing"
+)
+
+func Test_Releaser(t *testing.T) {
+	if os.Getenv("GITHUB_ACTIONS") == "true" {
+		t.Skip("Skip test on GitHub Actions")
+	}
+
+	if err := config.InitViper(nil); err != nil {
+		t.Fatalf("Failed to initialize viper: %v", err)
+	}
+	cfg := config.GetConfig()
+
+	c := zap.NewDevelopmentConfig()
+	c.Level.SetLevel(zap.InfoLevel)
+	logger, err := c.Build()
+	if err != nil {
+		t.Fatalf("Failed to create logger: %v", err)
+	}
+	zap.ReplaceGlobals(logger)
+
+	releaser, err := NewReleaser(*cfg)
+
+	if err != nil {
+		t.Fatalf("Failed to create Releaser: %v", err)
+	}
+
+	resource := &v1alpha1.GitHubReleaser{
+		Metadata: v1alpha1.Metadata{
+			Name: "test",
+		},
+		Spec: v1alpha1.GitHubReleaserSpec{
+			Org:  "jlewi",
+			Repo: "hydros-hydrated",
+		},
+	}
+	if err := releaser.Reconcile(context.Background(), resource); err != nil {
+		t.Fatalf("Failed to reconcile release: %+v", err)
+	}
+}

--- a/pkg/github/releaser_test.go
+++ b/pkg/github/releaser_test.go
@@ -2,11 +2,12 @@ package github
 
 import (
 	"context"
+	"os"
+	"testing"
+
 	"github.com/jlewi/hydros/api/v1alpha1"
 	"github.com/jlewi/hydros/pkg/config"
 	"go.uber.org/zap"
-	"os"
-	"testing"
 )
 
 func Test_Releaser(t *testing.T) {

--- a/pkg/gitops/repocontroller_test.go
+++ b/pkg/gitops/repocontroller_test.go
@@ -2,6 +2,7 @@ package gitops
 
 import (
 	"context"
+	"github.com/jlewi/hydros/pkg/config"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,6 +17,10 @@ func Test_repoController(t *testing.T) {
 		t.Skip("Skipping test because running in GHA")
 	}
 
+	if err := config.InitViper(nil); err != nil {
+		t.Fatalf("InitViper failed: %v", err)
+	}
+	hConfig := config.GetConfig()
 	util.SetupLogger("info", true)
 
 	cwd, err := os.Getwd()
@@ -33,9 +38,9 @@ func Test_repoController(t *testing.T) {
 		t.Fatalf("yaml decode failed: %v", err)
 	}
 
-	// Use the same workDir accross tests so we don't have to keep checking it out
-	workDir := "/tmp/hydros/repo_controller_test"
-	c, err := NewRepoController(repo, workDir)
+	// N.B. To use the same work directory and avoid checking out repos multiple times configure the workDir
+	// in your hydros config
+	c, err := NewRepoController(*hConfig, repo)
 	if err != nil {
 		t.Errorf("NewRepoController failed: %+v", err)
 	}

--- a/releases.yaml
+++ b/releases.yaml
@@ -1,0 +1,8 @@
+apiVersion: hydros.dev/v1alpha1
+kind: GitHubReleaser
+metadata:
+  name: hydros
+  namespace: hydros
+spec:
+  org: jlewi
+  repo: hydros

--- a/releasing.yaml
+++ b/releasing.yaml
@@ -5,7 +5,7 @@ metadata:
   name: hydros
   namespace: hydros
 spec:
-  repo: https://github.com/jlewi/hydros.git?ref=jlewi/ghreleaser
+  repo: https://github.com/jlewi/hydros.git
   globs:
     - "**/*.yaml"
   selectors:

--- a/releasing.yaml
+++ b/releasing.yaml
@@ -1,0 +1,13 @@
+# Use a RepoConfig to match resources in the hydros repository
+apiVersion: hydros.dev/v1alpha1
+kind: RepoConfig
+metadata:
+  name: hydros
+  namespace: hydros
+spec:
+  repo: https://github.com/jlewi/hydros.git?ref=jlewi/ghreleaser
+  globs:
+    - "**/*.yaml"
+  selectors:
+    - matchLabels:
+        env: release


### PR DESCRIPTION
1. **New GitHub Releaser Resource**: A new `GitHubReleaser` resource has been defined in `api/v1alpha1/releaser.go`, indicating functionality for automated GitHub releases based on specific conditions such as new commits to a repository.

1. **Releaser Implementation**: A new package `pkg/github/releaser.go` implements the logic for the GitHub Releaser functionality, including creating new GitHub releases and generating release notes automatically.

1. Create a `RepoConfig` and `GitHubReleaser` object to release hydros

1. **GitHub App Configuration Removal**: Changes in `api/v1alpha1/repo.go` remove the `GitHubAppConfig` from the `RepoSpec`, simplifying the configuration by focusing on repository URLs and glob patterns for file matching instead.
   
    * Now that we use Cobra the GitHubApp configuration should be provided in the hydros configuration not in the resource
 
1. **Improved Test Configuration**: Modifications to the Makefile introduce the use of a `GITHUB_ACTIONS` environment variable during tests to presumably alter behavior when tests are run in GitHub Actions CI/CD environments.

1. **Expanded Project Description**: The README.md file has been significantly updated to provide a more detailed introduction to Hydros, outlining its declarative approach to continuous delivery, and providing examples of how to use the tool. It also highlights the shift from the project being specifically tailored to Primer's workflow to a more generalized tool that could be beneficial to a broader audience.

1. **Detailed Documentation Updates**: Several documentation files, including `continuous_delivery.md` and `setup.md`, have been updated or added to provide in-depth guidance on setting up and using Hydros for continuous delivery, emphasizing its declarative nature and flexibility.

1. **GitHub Releaser Test**: A test case for the Releaser logic has been added to `pkg/github/releaser_test.go`, ensuring the functionality behaves as expected under specific conditions.

1. **Refined Repo Controller**: The `RepoController` logic within `pkg/gitops/repocontroller.go` and its test in `repocontroller_test.go` have been adjusted to accommodate the changes introduced, particularly the removal of GitHub app-specific configuration in favor of a more generalized approach.
