### PR TITLE
Support logging to GCP directly

### DIFF
--- a/cmd/commands/apply.go
+++ b/cmd/commands/apply.go
@@ -33,20 +33,20 @@ func NewApplyCmd() *cobra.Command {
 		Short: "Apply the specified resource.",
 		Run: func(cmd *cobra.Command, args []string) {
 			err := func() error {
-				log := zapr.NewLogger(zap.L())
-				if len(args) == 0 {
-					log.Info("apply takes at least one argument which should be the file or directory YAML to apply.")
-					return errors.New("apply takes at least one argument which should be the file or directory YAML to apply.")
-				}
-				logVersion()
-
 				app := app.NewApp()
+				defer app.Shutdown()
 				if err := app.LoadConfig(cmd); err != nil {
 					return err
 				}
 				if err := app.SetupLogging(); err != nil {
 					return err
 				}
+				log := zapr.NewLogger(zap.L())
+				if len(args) == 0 {
+					log.Info("apply takes at least one argument which should be the file or directory YAML to apply.")
+					return errors.New("apply takes at least one argument which should be the file or directory YAML to apply.")
+				}
+				logVersion()
 
 				if err := app.SetupRegistry(); err != nil {
 					return err

--- a/cmd/commands/build.go
+++ b/cmd/commands/build.go
@@ -2,6 +2,9 @@ package commands
 
 import (
 	"fmt"
+	"os"
+
+	"github.com/jlewi/hydros/pkg/app"
 
 	"github.com/jlewi/hydros/pkg/images"
 	"github.com/spf13/cobra"
@@ -17,8 +20,22 @@ func NewBuildCmd() *cobra.Command {
 		Use:   "build -f <resource.yaml>",
 		Short: "Build any images defined in the specified file",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := images.ReconcileFile(opts.File); err != nil {
-				fmt.Printf("takeover failed; error %+v\n", err)
+			err := func() error {
+				app := app.NewApp()
+				defer app.Shutdown()
+				if err := app.LoadConfig(cmd); err != nil {
+					return err
+				}
+				if err := app.SetupLogging(); err != nil {
+					return err
+				}
+				logVersion()
+				return images.ReconcileFile(opts.File)
+			}()
+
+			if err != nil {
+				fmt.Printf("build failed; error %+v\n", err)
+				os.Exit(1)
 			}
 		},
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -51,6 +51,10 @@ var (
 	rootCmd = &cobra.Command{
 		Short: "hydros is a tool to hydrate manifests",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			// TODO(jeremy): We really be using app to load the configuration and then call setup logging.
+			// Do we want to do that in a PreRun function? Or should we make it the responsibility of each command.
+			// I think we should make it the responsibility of each command as the processing could be slightly different
+			// for each command.
 			log = util.SetupLogger(gOptions.level, gOptions.devLogger)
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/google/go-github/v52 v52.0.0
 	github.com/gorilla/mux v1.8.0
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
-	github.com/jlewi/monogo v0.0.0-20240123191147-401afe194d74
+	github.com/jlewi/monogo v0.0.0-20240504194504-63d901f32136
 	github.com/jlewi/p22h/backend v0.0.0-20220627190823-9107137fbd82
 	github.com/palantir/go-githubapp v0.16.0
 	github.com/spf13/viper v1.10.0

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/google/go-github/v52 v52.0.0
 	github.com/gorilla/mux v1.8.0
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
-	github.com/jlewi/monogo v0.0.0-20240504194504-63d901f32136
+	github.com/jlewi/monogo v0.0.0-20240504200912-d99cae769a01
 	github.com/jlewi/p22h/backend v0.0.0-20220627190823-9107137fbd82
 	github.com/palantir/go-githubapp v0.16.0
 	github.com/spf13/viper v1.10.0
@@ -79,6 +79,7 @@ require (
 	cloud.google.com/go/compute v1.23.1 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/iam v1.1.3 // indirect
+	cloud.google.com/go/logging v1.8.1 // indirect
 	github.com/DataDog/datadog-go v4.8.3+incompatible // indirect
 	github.com/DataDog/sketches-go v1.0.0 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -461,6 +461,8 @@ github.com/jinzhu/now v1.1.4/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jlewi/monogo v0.0.0-20240123191147-401afe194d74 h1:pbOw/rOMs0AZ494bGnI6DieGKwqoJQEjHWaJZrvxsJo=
 github.com/jlewi/monogo v0.0.0-20240123191147-401afe194d74/go.mod h1:4QWrn/wb+L6rHHO3u5N250qJYWaZlHn1a8tFuWhZCP8=
+github.com/jlewi/monogo v0.0.0-20240504194504-63d901f32136 h1:LS+T7H4fR+Et6wlu8WMCiAbNRQLSmIAUA3kL+7hsixk=
+github.com/jlewi/monogo v0.0.0-20240504194504-63d901f32136/go.mod h1:s3nTD+owHZ6b+F13JdSpXLtrAH35pOqdwdcZEZ/gwBc=
 github.com/jlewi/p22h/backend v0.0.0-20220627190823-9107137fbd82 h1:RPy3iuJyBD3dU0Kg5XCk0EDiY5qHhikPlbHi350K1Aw=
 github.com/jlewi/p22h/backend v0.0.0-20220627190823-9107137fbd82/go.mod h1:JiaOBomo8HT5rxx+0Z5/18F/s4NN5qrDBA/+iRC6OGg=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ cloud.google.com/go/iam v0.3.0/go.mod h1:XzJPvDayI+9zsASAFO68Hk07u3z+f+JrT2xXNdp
 cloud.google.com/go/iam v1.1.3 h1:18tKG7DzydKWUnLjonWcJO6wjSCAtzh4GcRKlH/Hrzc=
 cloud.google.com/go/iam v1.1.3/go.mod h1:3khUlaBXfPKKe7huYgEpDn6FtgRyMEqbkvBxrQyY5SE=
 cloud.google.com/go/language v1.2.0/go.mod h1:CmExvQZvJq+O1c8Ljb6XDVufuSdDMT/PgGfkFiu7T/8=
+cloud.google.com/go/logging v1.8.1 h1:26skQWPeYhvIasWKm48+Eq7oUqdcdbwsCVwz5Ys0FvU=
+cloud.google.com/go/logging v1.8.1/go.mod h1:TJjR+SimHwuC8MZ9cjByQulAMgni+RkXeI3wwctHJEI=
 cloud.google.com/go/longrunning v0.5.2 h1:u+oFqfEwwU7F9dIELigxbe0XVnBAo9wqMuQLA50CZ5k=
 cloud.google.com/go/longrunning v0.5.2/go.mod h1:nqo6DQbNV2pXhGDbDMoN2bWz68MjZUzqv2YttZiveCs=
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
@@ -463,6 +465,8 @@ github.com/jlewi/monogo v0.0.0-20240123191147-401afe194d74 h1:pbOw/rOMs0AZ494bGn
 github.com/jlewi/monogo v0.0.0-20240123191147-401afe194d74/go.mod h1:4QWrn/wb+L6rHHO3u5N250qJYWaZlHn1a8tFuWhZCP8=
 github.com/jlewi/monogo v0.0.0-20240504194504-63d901f32136 h1:LS+T7H4fR+Et6wlu8WMCiAbNRQLSmIAUA3kL+7hsixk=
 github.com/jlewi/monogo v0.0.0-20240504194504-63d901f32136/go.mod h1:s3nTD+owHZ6b+F13JdSpXLtrAH35pOqdwdcZEZ/gwBc=
+github.com/jlewi/monogo v0.0.0-20240504200912-d99cae769a01 h1:mYQjD4rcVVrpFJPRrPSwqNyMH3Rm4VfIhCcFaGHaWNE=
+github.com/jlewi/monogo v0.0.0-20240504200912-d99cae769a01/go.mod h1:s3nTD+owHZ6b+F13JdSpXLtrAH35pOqdwdcZEZ/gwBc=
 github.com/jlewi/p22h/backend v0.0.0-20220627190823-9107137fbd82 h1:RPy3iuJyBD3dU0Kg5XCk0EDiY5qHhikPlbHi350K1Aw=
 github.com/jlewi/p22h/backend v0.0.0-20220627190823-9107137fbd82/go.mod h1:JiaOBomo8HT5rxx+0Z5/18F/s4NN5qrDBA/+iRC6OGg=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
@@ -636,6 +640,8 @@ github.com/philhofer/fwd v1.1.1 h1:GdGcTjf5RNAxwS4QLsiMzJYj5KEvPJD3Abr261yRQXQ=
 github.com/philhofer/fwd v1.1.1/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
 github.com/pjbgf/sha1cd v0.3.0 h1:4D5XXmUUBUl/xQ6IjCkEAbqXskkq/4O7LmGn0AqMDs4=
 github.com/pjbgf/sha1cd v0.3.0/go.mod h1:nZ1rrWOcGJ5uZgEEVL1VUM9iRQiZvWdbZjkKyFzPPsI=
+github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
+github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -21,6 +21,7 @@ import (
 	"github.com/jlewi/hydros/pkg/gitops"
 	"github.com/jlewi/hydros/pkg/images"
 	"github.com/jlewi/hydros/pkg/util"
+	"github.com/jlewi/monogo/gcp/logging"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
@@ -66,9 +67,13 @@ func (a *App) SetupLogging() error {
 
 	// Use the keys used by cloud logging
 	// https://cloud.google.com/logging/docs/structured-logging
-	c.EncoderConfig.LevelKey = "severity"
-	c.EncoderConfig.TimeKey = "time"
+	c.EncoderConfig.LevelKey = logging.SeverityField
+	c.EncoderConfig.TimeKey = logging.TimeField
 	c.EncoderConfig.MessageKey = "message"
+
+	if len(cfg.Logging.OutputPaths) > 0 {
+		c.OutputPaths = cfg.Logging.OutputPaths
+	}
 
 	lvl := cfg.GetLogLevel()
 	zapLvl := zap.NewAtomicLevel()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -45,6 +45,10 @@ type Config struct {
 
 type Logging struct {
 	Level string `json:"level,omitempty" yaml:"level,omitempty"`
+	// OutputPath is a list of paths to write logs to.
+	// Use stderr to write to stderr.
+	// Use gcplogs:///projects/${PROJECT}/logs/${LOGNAME} to write to Google Cloud Logging
+	OutputPaths []string `json:"outputPaths,omitempty" yaml:"outputPaths,omitempty"`
 }
 
 type GitHubConfig struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -43,12 +43,21 @@ type Config struct {
 	WorkDir string `json:"workDir,omitempty" yaml:"workDir,omitempty"`
 }
 
+// Logging configures the logging.
 type Logging struct {
 	Level string `json:"level,omitempty" yaml:"level,omitempty"`
-	// OutputPath is a list of paths to write logs to.
+	// Sinks is a list of sinks to write logs to.
 	// Use stderr to write to stderr.
 	// Use gcplogs:///projects/${PROJECT}/logs/${LOGNAME} to write to Google Cloud Logging
-	OutputPaths []string `json:"outputPaths,omitempty" yaml:"outputPaths,omitempty"`
+	Sinks []LogSink `json:"sinks,omitempty" yaml:"sinks,omitempty"`
+}
+
+type LogSink struct {
+	// Set to true to write logs in JSON format
+	JSON bool `json:"json,omitempty" yaml:"json,omitempty"`
+	// Path is the path to write logs to. Use "stderr" to write to stderr.
+	// Use gcplogs:///projects/${PROJECT}/logs/${LOGNAME} to write to Google Cloud Logging
+	Path string `json:"path,omitempty" yaml:"path,omitempty"`
 }
 
 type GitHubConfig struct {


### PR DESCRIPTION
We want to support the following logging configurations

* Emitting logs to stdout/stderr in non-JSON format
   * This is useful when running locally and the logs are directly consumed by humands
* Emitting logs to stdout/stderr in JSON format
  * This is useful when running on K8s and we want to emit structured logs that are automatically collected
* Emitting human logs to stdout and JSON logs directly to Cloud Logging
  * Useful when running locally and we want to stream logs to Cloud Logging for better analysis.

This requires refactoring the logger so we can setup separate cores; one for the console and one for the json logger. We can then use a tee to log to both of them.

* build command should use the logging configuration