### PR TITLE
Automatically recover if git repository is corrupted

### DIFF
--- a/docs/image_build.md
+++ b/docs/image_build.md
@@ -96,7 +96,7 @@ The build automatically tags the image with the following tags
 To build an image you can use the `hydros build` command
 
 ```bash
-hydros build ~/git_roboweb/kubedr/image.yaml
+hydros build -f ~/git_hydros/kubedr/images.yaml
 ```
 
 * If an image already exists in the registry with the same tag as the current commit, the image will not be rebuilt.


### PR DESCRIPTION
* We were periodically seeing errors opening up a previously cloned repository (#98)
* As noted in #98 it looks like certain critical .git files were missing leading to the local copy of the git repository to be corrupt.

* The hypothesis is that since we are using a temporary directory the OS might periodically GC the files

* In this case we can try to delete/rename the existing directory and then reclone the repository
* I chose to do a rename rather than a deletion to minimize the risk of data loss in the event we delete something that shouldn't be deleted.

Fix #98