### PR TITLE
Add support for GitHub into the key chain.

### DIFF
--- a/pkg/images/export.go
+++ b/pkg/images/export.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/google/go-containerregistry/pkg/crane"
-	"github.com/google/go-containerregistry/pkg/gcrane"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
@@ -15,7 +14,7 @@ import (
 //
 // This is different from image downloader because that appears to download the manifest and individual blobs.
 func ExportImage(src string, tarFilePath string) error {
-	options := []crane.Option{crane.WithAuthFromKeychain(gcrane.Keychain)}
+	options := []crane.Option{crane.WithAuthFromKeychain(keychain)}
 	var img v1.Image
 	desc, err := crane.Get(src, options...)
 	if err != nil {

--- a/pkg/images/keychain.go
+++ b/pkg/images/keychain.go
@@ -1,0 +1,19 @@
+package images
+
+import (
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/authn/github"
+	"github.com/google/go-containerregistry/pkg/v1/google"
+)
+
+var (
+	// TODO(jeremy): Should we add support for Azure and AWS?
+	// see https://github.com/google/go-containerregistry/pull/1252/files#diff-d062be9a5715169ccabeaa8a2d525b7340f8ec9a7534b3a27dfd1ae35148de29
+	// for how we could do that.
+	// TODO(jeremy): Should we use K8s chain? https://github.com/google/go-containerregistry/blob/main/pkg/authn/k8schain/README.md
+	keychain = authn.NewMultiKeychain(
+		authn.DefaultKeychain,
+		google.Keychain,
+		github.Keychain,
+	)
+)

--- a/pkg/images/replicator.go
+++ b/pkg/images/replicator.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/go-logr/zapr"
 	"github.com/google/go-containerregistry/pkg/crane"
-	"github.com/google/go-containerregistry/pkg/gcrane"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
@@ -27,8 +26,8 @@ type Replicator struct {
 // NewReplicator creates a new Replicator.
 func NewReplicator() (*Replicator, error) {
 	// TODO(jeremy): What's a better pattern for handling options for crane.
-	rOptions := []remote.Option{remote.WithAuthFromKeychain(gcrane.Keychain)}
-	options := []crane.Option{crane.WithAuthFromKeychain(gcrane.Keychain)}
+	rOptions := []remote.Option{remote.WithAuthFromKeychain(keychain)}
+	options := []crane.Option{crane.WithAuthFromKeychain(keychain)}
 
 	r := &Replicator{
 		rOptions: rOptions,


### PR DESCRIPTION
* We want to be able to run hydros in cluster and authenticate to GHCR
* To do that we include github.Keychain which will look for GITHUB_TOKEN environment variable

  * see https://github.com/google/go-containerregistry/pull/1252/